### PR TITLE
feat(tauri): persist windows + close=remove + --no-restore (#105)

### DIFF
--- a/crates/notesmith-tauri/capabilities/vault-windows.json
+++ b/crates/notesmith-tauri/capabilities/vault-windows.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri/schema.json",
+  "identifier": "vault-windows",
+  "description": "Capability granted to every per-vault window (main:*).",
+  "windows": ["main:*"],
+  "permissions": [
+    "core:default",
+    "shell:allow-open",
+    "deep-link:default"
+  ]
+}

--- a/crates/notesmith-tauri/src/lib.rs
+++ b/crates/notesmith-tauri/src/lib.rs
@@ -2,3 +2,4 @@
 
 pub mod daemon;
 pub mod vault_window;
+pub mod windows_persist;

--- a/crates/notesmith-tauri/src/main.rs
+++ b/crates/notesmith-tauri/src/main.rs
@@ -13,8 +13,12 @@ use std::time::{Duration, Instant};
 
 use notesmith_tauri::daemon::{self, DaemonSettings, DaemonState, DynError};
 use notesmith_tauri::vault_window::{is_vault_window_label, vault_app_url, vault_window_label};
+use notesmith_tauri::windows_persist::{
+    self, Rect, WindowEntry, WindowsFile, dedupe_latest_per_vault,
+};
 use tauri::{
-    AppHandle, Manager, RunEvent, Runtime, UriSchemeContext, Url, WebviewUrl, WebviewWindowBuilder,
+    AppHandle, Emitter, Manager, RunEvent, Runtime, UriSchemeContext, Url, WebviewUrl,
+    WebviewWindowBuilder,
     menu::{Menu, MenuItem, PredefinedMenuItem, Submenu},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
 };
@@ -41,6 +45,17 @@ const DAEMON_CRASH_WINDOW: Duration = Duration::from_secs(60);
 const DAEMON_CRASH_THRESHOLD: usize = 2;
 const DAEMON_CRASH_LOG_LINES: usize = 200;
 const QUIT_CONFIRM_WINDOW: Duration = Duration::from_secs(5);
+
+/// Debounce window-geometry writes so a drag doesn't trigger hundreds of
+/// `windows.json` rewrites.
+const WINDOWS_PERSIST_DEBOUNCE: Duration = Duration::from_millis(500);
+
+/// CLI flag that suppresses `windows.json` replay for one launch.
+const NO_RESTORE_FLAG: &str = "--no-restore";
+
+/// Frontend event emitted when the user clicks the OS close button. The
+/// webview must respond by invoking `confirm_window_close`.
+const CLOSE_REQUESTED_EVENT: &str = "notesmith://close-requested";
 
 #[derive(Default)]
 struct ExitState(AtomicBool);
@@ -222,9 +237,8 @@ impl Default for DaemonUrlState {
 ///
 /// Used to implement focus-existing: opening a vault that already has a window
 /// re-focuses that window rather than creating a duplicate. Entries are added
-/// when [`ensure_vault_window`] creates a window. Entries are **not** removed
-/// on close while #105 (real close semantics) is unimplemented — close still
-/// hides the window today, so the map entry remains valid.
+/// when [`ensure_vault_window`] creates a window and removed when the user
+/// confirms a real close (see [`confirm_window_close`]).
 #[derive(Default)]
 struct VaultWindows(Mutex<HashMap<String, String>>);
 
@@ -243,6 +257,99 @@ impl VaultWindows {
             .expect("vault windows state poisoned")
             .insert(vault, label);
     }
+
+    /// Remove and return the vault associated with the given window label.
+    fn remove_label(&self, label: &str) -> Option<String> {
+        let mut guard = self.0.lock().expect("vault windows state poisoned");
+        let vault = guard
+            .iter()
+            .find_map(|(k, v)| (v == label).then(|| k.clone()))?;
+        guard.remove(&vault);
+        Some(vault)
+    }
+}
+
+/// Tracks the path to `windows.json` plus a debounced timestamp for the next
+/// flush. The timestamp gates noisy geometry-change writes during a drag.
+#[derive(Default)]
+struct WindowsPersistState {
+    inner: Mutex<WindowsPersistInner>,
+}
+
+#[derive(Default)]
+struct WindowsPersistInner {
+    path: Option<PathBuf>,
+    last_write: Option<Instant>,
+    /// Whether this launch should ignore an existing `windows.json` (the
+    /// file itself stays on disk; we just skip the replay).
+    no_restore: bool,
+}
+
+impl WindowsPersistState {
+    fn set_path(&self, path: PathBuf) {
+        self.inner.lock().expect("windows persist poisoned").path = Some(path);
+    }
+
+    fn path(&self) -> Option<PathBuf> {
+        self.inner
+            .lock()
+            .expect("windows persist poisoned")
+            .path
+            .clone()
+    }
+
+    fn set_no_restore(&self, value: bool) {
+        self.inner
+            .lock()
+            .expect("windows persist poisoned")
+            .no_restore = value;
+    }
+
+    fn no_restore(&self) -> bool {
+        self.inner
+            .lock()
+            .expect("windows persist poisoned")
+            .no_restore
+    }
+
+    /// Returns true if at least `WINDOWS_PERSIST_DEBOUNCE` has elapsed since
+    /// the last write (or no write has happened yet). Resets the debounce
+    /// clock when it returns `true`.
+    fn try_take_debounce_slot(&self) -> bool {
+        let mut guard = self.inner.lock().expect("windows persist poisoned");
+        let now = Instant::now();
+        let ready = match guard.last_write {
+            Some(prev) => now.duration_since(prev) >= WINDOWS_PERSIST_DEBOUNCE,
+            None => true,
+        };
+        if ready {
+            guard.last_write = Some(now);
+        }
+        ready
+    }
+}
+
+/// Set of window labels that have been approved by the webview for a real
+/// close. The close handler in `on_window_event` checks this set: if present,
+/// it lets the OS close the window; otherwise it prevents the close and asks
+/// the webview to confirm via `CLOSE_REQUESTED_EVENT`.
+#[derive(Default)]
+struct PendingCloses(Mutex<std::collections::HashSet<String>>);
+
+impl PendingCloses {
+    fn allow(&self, label: &str) {
+        self.0
+            .lock()
+            .expect("pending closes poisoned")
+            .insert(label.to_string());
+    }
+
+    fn take(&self, label: &str) -> bool {
+        self.0
+            .lock()
+            .expect("pending closes poisoned")
+            .remove(label)
+    }
 }
 
 fn main() {
@@ -255,6 +362,8 @@ fn main() {
         .manage(DaemonUrlState::default())
         .manage(DaemonProcessState::default())
         .manage(VaultWindows::default())
+        .manage(WindowsPersistState::default())
+        .manage(PendingCloses::default())
         .manage(InternalHtmlState(Mutex::new(InternalPages {
             fallback: None,
         })))
@@ -268,7 +377,8 @@ fn main() {
             view_crash_report,
             restart_daemon_anyway,
             open_vault_window,
-            set_window_title
+            set_window_title,
+            confirm_window_close
         ])
         .menu(build_app_menu)
         .on_menu_event(|app, event| {
@@ -288,12 +398,51 @@ fn main() {
             }
         })
         .on_window_event(|window, event| {
-            let label = window.label();
-            if (label == MAIN_WINDOW_LABEL || is_vault_window_label(label))
-                && let tauri::WindowEvent::CloseRequested { api, .. } = event
-            {
-                api.prevent_close();
-                let _ = window.hide();
+            let label = window.label().to_string();
+            match event {
+                tauri::WindowEvent::CloseRequested { api, .. } => {
+                    if label == MAIN_WINDOW_LABEL {
+                        // Onboarding window: keep legacy hide behaviour.
+                        api.prevent_close();
+                        let _ = window.hide();
+                    } else if is_vault_window_label(&label) {
+                        let app = window.app_handle();
+                        if app.state::<PendingCloses>().take(&label) {
+                            // Webview already confirmed; let the OS close it.
+                            handle_vault_window_destroyed(app, &label);
+                        } else {
+                            // Ask the webview to confirm. If no listener is
+                            // attached, the close request silently sticks —
+                            // user can close again to force.
+                            api.prevent_close();
+                            let _ = window.emit(CLOSE_REQUESTED_EVENT, label.clone());
+                        }
+                    }
+                }
+                tauri::WindowEvent::Moved(_) | tauri::WindowEvent::Resized(_) => {
+                    if is_vault_window_label(&label) {
+                        let app = window.app_handle().clone();
+                        let label = label.clone();
+                        // Debounce in-process: only one writer wins per slot.
+                        if app
+                            .state::<WindowsPersistState>()
+                            .try_take_debounce_slot()
+                        {
+                            tauri::async_runtime::spawn(async move {
+                                tauri::async_runtime::spawn_blocking(move || {
+                                    if let Err(error) = persist_open_windows(&app) {
+                                        tracing::warn!(
+                                            "failed to persist windows after geometry change ({label}): {error}"
+                                        );
+                                    }
+                                })
+                                .await
+                                .ok();
+                            });
+                        }
+                    }
+                }
+                _ => {}
             }
         })
         .setup(|app| {
@@ -309,16 +458,41 @@ fn main() {
         {
             api.prevent_exit();
         }
+        RunEvent::ExitRequested { .. } => {
+            // Last chance to flush persistence before the process exits.
+            if let Err(error) = persist_open_windows(app_handle) {
+                tracing::warn!("failed to flush windows.json on exit: {error}");
+            }
+        }
         RunEvent::Resumed => emit_wake_event(app_handle),
         _ => {}
     });
 }
 
 fn initialize_app(app: &tauri::App) -> Result<(), DynError> {
-    show_splash_window(app.handle())?;
-    setup_tray(app.handle())?;
-    setup_deep_links(app.handle())?;
-    tauri::async_runtime::block_on(run_startup_flow(app.handle()))?;
+    let handle = app.handle();
+
+    // Configure persistence path and the --no-restore CLI flag before any
+    // window-event handler fires.
+    if let Ok(config_dir) = handle.path().app_config_dir() {
+        handle
+            .state::<WindowsPersistState>()
+            .set_path(windows_persist::windows_file_path(&config_dir));
+    } else {
+        tracing::warn!("app config dir unavailable; windows.json will not be persisted");
+    }
+    let no_restore = std::env::args().any(|arg| arg == NO_RESTORE_FLAG);
+    handle
+        .state::<WindowsPersistState>()
+        .set_no_restore(no_restore);
+    if no_restore {
+        tracing::info!("{NO_RESTORE_FLAG} detected; skipping windows.json replay this launch");
+    }
+
+    show_splash_window(handle)?;
+    setup_tray(handle)?;
+    setup_deep_links(handle)?;
+    tauri::async_runtime::block_on(run_startup_flow(handle))?;
     Ok(())
 }
 
@@ -909,7 +1083,183 @@ fn ensure_vault_window<R: Runtime>(app: &AppHandle<R>, vault: &str) -> Result<St
 
     app.state::<VaultWindows>()
         .insert(vault.to_string(), label.clone());
+
+    // New window — schedule a persistence flush so windows.json reflects it.
+    schedule_persist(app);
+
     Ok(label)
+}
+
+/// Open a vault window and apply the saved geometry from `windows.json`.
+///
+/// Used by the restore-from-disk path. Differs from `ensure_vault_window` in
+/// that it positions/sizes the new window after creation. Existing windows
+/// are left untouched (we don't overwrite the user's current geometry).
+fn ensure_vault_window_with_geometry<R: Runtime>(
+    app: &AppHandle<R>,
+    vault: &str,
+    entry: &WindowEntry,
+) -> Result<String, DynError> {
+    let label = ensure_vault_window(app, vault)?;
+    if let Some(window) = app.get_webview_window(&label) {
+        // Clamp to a visible monitor so windows from a now-disconnected
+        // display don't end up off-screen.
+        let rect = clamp_to_visible_monitors(&window, entry);
+        let _ = window.set_position(tauri::PhysicalPosition {
+            x: rect.x,
+            y: rect.y,
+        });
+        let _ = window.set_size(tauri::PhysicalSize {
+            width: rect.w,
+            height: rect.h,
+        });
+    }
+    Ok(label)
+}
+
+fn clamp_to_visible_monitors<R: Runtime>(
+    window: &tauri::WebviewWindow<R>,
+    entry: &WindowEntry,
+) -> Rect {
+    let monitors = window
+        .available_monitors()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|m| {
+            let pos = m.position();
+            let size = m.size();
+            Rect {
+                x: pos.x,
+                y: pos.y,
+                w: size.width,
+                h: size.height,
+            }
+        })
+        .collect::<Vec<_>>();
+    windows_persist::clamp_to_monitor(
+        Rect {
+            x: entry.x,
+            y: entry.y,
+            w: entry.w,
+            h: entry.h,
+        },
+        &monitors,
+    )
+}
+
+/// Snapshot the open vault windows and write `windows.json` atomically.
+///
+/// Skipped silently when the persistence path hasn't been configured (e.g.
+/// the app_config_dir lookup failed at startup).
+fn persist_open_windows<R: Runtime>(app: &AppHandle<R>) -> io::Result<()> {
+    let Some(path) = app.state::<WindowsPersistState>().path() else {
+        return Ok(());
+    };
+
+    let entries = snapshot_window_entries(app);
+    let file = WindowsFile {
+        version: windows_persist::SCHEMA_VERSION,
+        windows: dedupe_latest_per_vault(entries),
+    };
+    windows_persist::save(&path, &file)
+}
+
+fn snapshot_window_entries<R: Runtime>(app: &AppHandle<R>) -> Vec<WindowEntry> {
+    let mapping: Vec<(String, String)> = app
+        .state::<VaultWindows>()
+        .0
+        .lock()
+        .expect("vault windows state poisoned")
+        .iter()
+        .map(|(vault, label)| (vault.clone(), label.clone()))
+        .collect();
+
+    let mut out = Vec::with_capacity(mapping.len());
+    for (vault, label) in mapping {
+        let Some(window) = app.get_webview_window(&label) else {
+            continue;
+        };
+        let pos = match window.outer_position() {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        let size = match window.outer_size() {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        out.push(WindowEntry {
+            vault,
+            x: pos.x,
+            y: pos.y,
+            w: size.width,
+            h: size.height,
+        });
+    }
+    out
+}
+
+/// Spawn a non-blocking persistence flush.
+fn schedule_persist<R: Runtime>(app: &AppHandle<R>) {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        tauri::async_runtime::spawn_blocking(move || {
+            if let Err(error) = persist_open_windows(&app) {
+                tracing::warn!("failed to persist windows.json: {error}");
+            }
+        })
+        .await
+        .ok();
+    });
+}
+
+/// Called after a vault window has actually closed.
+///
+/// Removes the entry from [`VaultWindows`] and rewrites `windows.json` so a
+/// subsequent launch doesn't reopen the closed window.
+fn handle_vault_window_destroyed<R: Runtime>(app: &AppHandle<R>, label: &str) {
+    app.state::<VaultWindows>().remove_label(label);
+    schedule_persist(app);
+}
+
+/// Replay `windows.json` and open one window per saved entry.
+///
+/// Returns the number of windows opened (0 when the file is missing, empty,
+/// corrupt, or when `--no-restore` is in effect).
+fn restore_windows_from_disk<R: Runtime>(app: &AppHandle<R>) -> usize {
+    let state = app.state::<WindowsPersistState>();
+    if state.no_restore() {
+        return 0;
+    }
+    let Some(path) = state.path() else {
+        return 0;
+    };
+    let file = match windows_persist::load(&path) {
+        Ok(Some(file)) => file,
+        Ok(None) => return 0,
+        Err(error) => {
+            tracing::warn!("failed to load windows.json: {error}");
+            return 0;
+        }
+    };
+
+    let mut opened = 0;
+    for entry in &file.windows {
+        match ensure_vault_window_with_geometry(app, &entry.vault, entry) {
+            Ok(label) => {
+                if let Some(window) = app.get_webview_window(&label) {
+                    let _ = window.show();
+                }
+                opened += 1;
+            }
+            Err(error) => {
+                tracing::warn!(
+                    "failed to restore vault window for '{}': {error}",
+                    entry.vault
+                );
+            }
+        }
+    }
+    opened
 }
 
 /// Returns the configured default vault, or the first registered vault when
@@ -963,6 +1313,14 @@ fn show_main_app_window<R: Runtime>(
     close_window(app, FALLBACK_WINDOW_LABEL)?;
     set_current_daemon_url(app, daemon::resolve_daemon_url(settings));
 
+    // First: replay persisted windows so a user who had two vaults open
+    // gets both back. If anything was restored, we're done.
+    if restore_windows_from_disk(app) > 0 {
+        return Ok(());
+    }
+
+    // Otherwise, fall back to opening the default vault (existing behaviour)
+    // or onboarding when no vaults exist.
     match resolve_default_vault() {
         Some(vault) => {
             let label = ensure_vault_window(app, &vault)?;
@@ -1755,6 +2113,42 @@ async fn open_vault_window(app: tauri::AppHandle, vault: String) -> Result<(), S
 #[tauri::command]
 fn set_window_title(window: tauri::Window, title: String) -> Result<(), String> {
     window.set_title(&title).map_err(|error| error.to_string())
+}
+
+/// Webview response to a `notesmith://close-requested` event.
+///
+/// - `allow=true`: the webview has saved/discarded any dirty content and is
+///   ready to be torn down. We mark the window as approved-for-close, remove
+///   the vault binding, then close the window. Closing the window fires
+///   `CloseRequested` again, which finds the marker and lets the OS proceed.
+/// - `allow=false`: the user cancelled; clear nothing extra (no marker was
+///   set) and leave the window where it is.
+#[tauri::command]
+async fn confirm_window_close(
+    app: tauri::AppHandle,
+    window: tauri::Window,
+    allow: bool,
+) -> Result<(), String> {
+    let label = window.label().to_string();
+    if !is_vault_window_label(&label) {
+        return Err(format!("not a vault window: {label}"));
+    }
+    if !allow {
+        return Ok(());
+    }
+    app.state::<PendingCloses>().allow(&label);
+
+    // Remove from VaultWindows now so any focus-existing lookup in the brief
+    // window between this call and the OS destroying the window opens a new
+    // window instead of pointing at a soon-to-be-dead one.
+    app.state::<VaultWindows>().remove_label(&label);
+
+    if let Some(webview) = app.get_webview_window(&label) {
+        webview.close().map_err(|error| error.to_string())?;
+    }
+    // Geometry has been removed; rewrite windows.json.
+    schedule_persist(&app);
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/notesmith-tauri/src/windows_persist.rs
+++ b/crates/notesmith-tauri/src/windows_persist.rs
@@ -1,0 +1,389 @@
+//! Persistence for the set of open vault windows.
+//!
+//! On every meaningful change (a window opens, moves, resizes, or closes) we
+//! atomically rewrite `windows.json` in the app config directory. On launch we
+//! replay the file to re-open each vault window at its saved geometry.
+//!
+//! All filesystem I/O and the pure geometry helpers (`clamp_to_monitor`,
+//! `dedupe_latest_per_vault`) live here so they can be unit tested without a
+//! running Tauri runtime.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Current schema version. Bump and add a migration when fields change.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// On-disk representation of the open-window set.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WindowsFile {
+    pub version: u32,
+    #[serde(default)]
+    pub windows: Vec<WindowEntry>,
+}
+
+impl Default for WindowsFile {
+    fn default() -> Self {
+        Self {
+            version: SCHEMA_VERSION,
+            windows: Vec::new(),
+        }
+    }
+}
+
+/// One persisted vault window.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WindowEntry {
+    pub vault: String,
+    pub x: i32,
+    pub y: i32,
+    pub w: u32,
+    pub h: u32,
+}
+
+/// Rectangle in screen coordinates. Used for monitor-bounds clamping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Rect {
+    pub x: i32,
+    pub y: i32,
+    pub w: u32,
+    pub h: u32,
+}
+
+/// Return the path to `windows.json` inside the given config directory.
+pub fn windows_file_path(config_dir: &Path) -> PathBuf {
+    config_dir.join("windows.json")
+}
+
+/// Load and parse `windows.json`. Missing, empty, or corrupt files return
+/// `Ok(None)` so the caller can fall back to first-launch flow.
+pub fn load(path: &Path) -> io::Result<Option<WindowsFile>> {
+    let bytes = match fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    if bytes.is_empty() {
+        return Ok(None);
+    }
+    match serde_json::from_slice::<WindowsFile>(&bytes) {
+        Ok(file) if file.version == SCHEMA_VERSION => Ok(Some(file)),
+        _ => Ok(None),
+    }
+}
+
+/// Atomically write `windows.json` by serialising to a sibling `.tmp` file
+/// and renaming. The parent directory must already exist.
+pub fn save(path: &Path, file: &WindowsFile) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let tmp_path = match path.extension() {
+        Some(ext) => {
+            let mut new_ext = ext.to_os_string();
+            new_ext.push(".tmp");
+            path.with_extension(new_ext)
+        }
+        None => path.with_extension("tmp"),
+    };
+    let bytes = serde_json::to_vec_pretty(file)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    fs::write(&tmp_path, bytes)?;
+    fs::rename(&tmp_path, path)?;
+    Ok(())
+}
+
+/// Collapse multiple entries for the same vault, keeping the last one in
+/// document order. The on-disk invariant is "at most one entry per vault".
+pub fn dedupe_latest_per_vault(entries: Vec<WindowEntry>) -> Vec<WindowEntry> {
+    let mut seen: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    let mut result: Vec<WindowEntry> = Vec::with_capacity(entries.len());
+    for entry in entries {
+        if let Some(&index) = seen.get(&entry.vault) {
+            result[index] = entry;
+        } else {
+            seen.insert(entry.vault.clone(), result.len());
+            result.push(entry);
+        }
+    }
+    result
+}
+
+/// Clamp `rect` so that it intersects one of the given `monitors`. If the
+/// rect is fully off-screen (no overlap with any monitor), centre it inside
+/// the first monitor. Returns the (possibly adjusted) rectangle.
+pub fn clamp_to_monitor(rect: Rect, monitors: &[Rect]) -> Rect {
+    if monitors.is_empty() {
+        return rect;
+    }
+
+    if monitors.iter().any(|m| overlaps(rect, *m)) {
+        return rect;
+    }
+
+    let primary = monitors[0];
+    let w = rect.w.min(primary.w);
+    let h = rect.h.min(primary.h);
+    let x = primary.x + ((primary.w.saturating_sub(w)) / 2) as i32;
+    let y = primary.y + ((primary.h.saturating_sub(h)) / 2) as i32;
+    Rect { x, y, w, h }
+}
+
+fn overlaps(a: Rect, b: Rect) -> bool {
+    let a_right = a.x.saturating_add(a.w as i32);
+    let a_bottom = a.y.saturating_add(a.h as i32);
+    let b_right = b.x.saturating_add(b.w as i32);
+    let b_bottom = b.y.saturating_add(b.h as i32);
+    a.x < b_right && a_right > b.x && a.y < b_bottom && a_bottom > b.y
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    fn tmp_dir() -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!("ns-windows-persist-{nanos}-{counter}"));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn sample_file() -> WindowsFile {
+        WindowsFile {
+            version: SCHEMA_VERSION,
+            windows: vec![
+                WindowEntry {
+                    vault: "personal".into(),
+                    x: 100,
+                    y: 80,
+                    w: 1200,
+                    h: 800,
+                },
+                WindowEntry {
+                    vault: "work".into(),
+                    x: 200,
+                    y: 120,
+                    w: 1100,
+                    h: 750,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn round_trip_serialises_and_deserialises() {
+        let dir = tmp_dir();
+        let path = windows_file_path(&dir);
+        let file = sample_file();
+
+        save(&path, &file).unwrap();
+        let loaded = load(&path).unwrap().expect("file should exist");
+
+        assert_eq!(loaded, file);
+    }
+
+    #[test]
+    fn load_returns_none_when_file_missing() {
+        let dir = tmp_dir();
+        let path = windows_file_path(&dir);
+        assert!(load(&path).unwrap().is_none());
+    }
+
+    #[test]
+    fn load_returns_none_when_file_empty() {
+        let dir = tmp_dir();
+        let path = windows_file_path(&dir);
+        fs::write(&path, b"").unwrap();
+        assert!(load(&path).unwrap().is_none());
+    }
+
+    #[test]
+    fn load_returns_none_when_file_corrupt() {
+        let dir = tmp_dir();
+        let path = windows_file_path(&dir);
+        fs::write(&path, b"{ this is not json").unwrap();
+        assert!(load(&path).unwrap().is_none());
+    }
+
+    #[test]
+    fn load_returns_none_for_unknown_schema_version() {
+        let dir = tmp_dir();
+        let path = windows_file_path(&dir);
+        fs::write(&path, br#"{"version":999,"windows":[]}"#).unwrap();
+        assert!(load(&path).unwrap().is_none());
+    }
+
+    #[test]
+    fn save_writes_through_tmp_file_then_renames() {
+        let dir = tmp_dir();
+        let path = windows_file_path(&dir);
+        save(&path, &sample_file()).unwrap();
+
+        // tmp file must be gone after a successful rename
+        let tmp = path.with_extension("json.tmp");
+        assert!(!tmp.exists(), "leftover tmp file: {tmp:?}");
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn save_creates_parent_directories() {
+        let dir = tmp_dir().join("nested").join("config");
+        let path = windows_file_path(&dir);
+        save(&path, &sample_file()).unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn save_overwrites_existing_file_atomically() {
+        let dir = tmp_dir();
+        let path = windows_file_path(&dir);
+        save(&path, &sample_file()).unwrap();
+
+        let mut updated = sample_file();
+        updated.windows[0].x = 999;
+        save(&path, &updated).unwrap();
+
+        let loaded = load(&path).unwrap().unwrap();
+        assert_eq!(loaded.windows[0].x, 999);
+    }
+
+    #[test]
+    fn dedupe_keeps_latest_entry_per_vault() {
+        let entries = vec![
+            WindowEntry {
+                vault: "a".into(),
+                x: 0,
+                y: 0,
+                w: 100,
+                h: 100,
+            },
+            WindowEntry {
+                vault: "b".into(),
+                x: 1,
+                y: 1,
+                w: 100,
+                h: 100,
+            },
+            WindowEntry {
+                vault: "a".into(),
+                x: 50,
+                y: 50,
+                w: 200,
+                h: 200,
+            },
+        ];
+
+        let result = dedupe_latest_per_vault(entries);
+
+        assert_eq!(result.len(), 2);
+        let a = result.iter().find(|e| e.vault == "a").unwrap();
+        assert_eq!(a.x, 50);
+        assert_eq!(a.w, 200);
+    }
+
+    #[test]
+    fn clamp_returns_rect_unchanged_when_it_overlaps_a_monitor() {
+        let monitor = Rect {
+            x: 0,
+            y: 0,
+            w: 1920,
+            h: 1080,
+        };
+        let rect = Rect {
+            x: 100,
+            y: 100,
+            w: 800,
+            h: 600,
+        };
+        assert_eq!(clamp_to_monitor(rect, &[monitor]), rect);
+    }
+
+    #[test]
+    fn clamp_recentres_when_rect_is_fully_off_screen() {
+        let monitor = Rect {
+            x: 0,
+            y: 0,
+            w: 1920,
+            h: 1080,
+        };
+        // Rect way off to the right
+        let rect = Rect {
+            x: 5000,
+            y: 5000,
+            w: 800,
+            h: 600,
+        };
+        let clamped = clamp_to_monitor(rect, &[monitor]);
+        assert_eq!(clamped.w, 800);
+        assert_eq!(clamped.h, 600);
+        // Should be centred: (1920-800)/2 = 560, (1080-600)/2 = 240
+        assert_eq!(clamped.x, 560);
+        assert_eq!(clamped.y, 240);
+    }
+
+    #[test]
+    fn clamp_keeps_rect_when_overlapping_secondary_monitor() {
+        let primary = Rect {
+            x: 0,
+            y: 0,
+            w: 1920,
+            h: 1080,
+        };
+        let secondary = Rect {
+            x: 1920,
+            y: 0,
+            w: 1920,
+            h: 1080,
+        };
+        let rect = Rect {
+            x: 2000,
+            y: 100,
+            w: 800,
+            h: 600,
+        };
+        assert_eq!(clamp_to_monitor(rect, &[primary, secondary]), rect);
+    }
+
+    #[test]
+    fn clamp_shrinks_rect_to_fit_when_recentring_a_huge_window() {
+        let monitor = Rect {
+            x: 0,
+            y: 0,
+            w: 1000,
+            h: 1000,
+        };
+        let rect = Rect {
+            x: 5000,
+            y: 5000,
+            w: 2000,
+            h: 2000,
+        };
+        let clamped = clamp_to_monitor(rect, &[monitor]);
+        assert_eq!(clamped.w, 1000);
+        assert_eq!(clamped.h, 1000);
+        assert_eq!(clamped.x, 0);
+        assert_eq!(clamped.y, 0);
+    }
+
+    #[test]
+    fn clamp_returns_rect_unchanged_when_no_monitors_known() {
+        let rect = Rect {
+            x: 10,
+            y: 10,
+            w: 100,
+            h: 100,
+        };
+        assert_eq!(clamp_to_monitor(rect, &[]), rect);
+    }
+}

--- a/crates/notesmith-tauri/tauri.conf.json
+++ b/crates/notesmith-tauri/tauri.conf.json
@@ -9,7 +9,7 @@
   },
   "app": {
     "macOSPrivateApi": true,
-    "withGlobalTauri": false,
+    "withGlobalTauri": true,
     "windows": [
       {
         "label": "main",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -54,6 +54,16 @@ cd crates/notesmith-tauri && cargo tauri build
 
 > Building with `cargo tauri ...` requires the Tauri CLI (`cargo install tauri-cli`) and platform tooling such as Xcode command line tools on macOS.
 
+### Desktop launch flags
+
+The desktop binary accepts a small set of flags before any Tauri-specific arguments:
+
+| Flag | Description |
+|------|-------------|
+| `--no-restore` | Skip the per-vault window restore on launch. Opens a single window on the default vault instead of replaying `windows.json`. The file is **not deleted** — only ignored for this launch. Useful when a saved window position has become problematic (e.g. a stale monitor layout). |
+
+`windows.json` lives in the platform app-config directory (`~/Library/Application Support/com.notesmith.desktop/windows.json` on macOS) and stores `{ vault, x, y, w, h }` for every currently-open vault window. It is rewritten atomically on window create, move, resize, real close, and app quit.
+
 ---
 
 ## mcp

--- a/ui/app/src/lib/app-shell.svelte.ts
+++ b/ui/app/src/lib/app-shell.svelte.ts
@@ -5,11 +5,27 @@ import { connectSSE } from './sse';
 import { saveQueue } from './save-queue.ts';
 import { tabStore } from './tab-store.svelte';
 import { vaultStore } from './stores.svelte';
+import { attachWindowCloseConfirm } from './window-lifecycle.ts';
 
 export { classifyAppShellEvent, type AppShellEvent } from './app-shell-core.ts';
 export type { AppShellCallbacks } from './app-shell-core.ts';
 
 export function createAppShell(callbacks: AppShellCallbacks) {
+	// Register the Tauri close-confirm bridge once per window mount. The
+	// promise resolves to an unlisten fn; we don't currently expose a tear-
+	// down hook because the listener should live for the lifetime of the
+	// window. In tests the adapter resolves to null and this is a no-op.
+	void attachWindowCloseConfirm({
+		hasDirtyWork: () => tabStore.tabs.some((tab) => tab.dirty),
+		confirmDiscard: () =>
+			typeof window !== 'undefined' &&
+			typeof window.confirm === 'function'
+				? window.confirm(
+						'You have unsaved changes in this vault. Close the window and discard them?'
+					)
+				: true
+	});
+
 	return createCoreAppShell(callbacks, {
 		connectSSE,
 		listVaults,

--- a/ui/app/src/lib/window-lifecycle.test.ts
+++ b/ui/app/src/lib/window-lifecycle.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from 'vitest';
+import { attachWindowCloseConfirm, type TauriAdapter } from './window-lifecycle';
+
+function makeTauri(): {
+  adapter: TauriAdapter;
+  fire: (payload?: unknown) => Promise<void>;
+  invoke: ReturnType<typeof vi.fn>;
+  unlisten: ReturnType<typeof vi.fn>;
+} {
+  let handler: ((payload: unknown) => void) | null = null;
+  const unlisten = vi.fn();
+  const invoke = vi.fn(async () => undefined);
+  const adapter: TauriAdapter = {
+    listen: async (_event, h) => {
+      handler = h;
+      return unlisten;
+    },
+    invoke
+  };
+  return {
+    adapter,
+    invoke,
+    unlisten,
+    fire: async (payload) => {
+      handler?.(payload);
+      await Promise.resolve();
+      await Promise.resolve();
+    }
+  };
+}
+
+describe('attachWindowCloseConfirm', () => {
+  it('invokes confirm_window_close with allow:true when no tabs are dirty', async () => {
+    const { adapter, fire, invoke } = makeTauri();
+    await attachWindowCloseConfirm({
+      hasDirtyWork: () => false,
+      confirmDiscard: () => false,
+      tauri: adapter
+    });
+
+    await fire();
+
+    expect(invoke).toHaveBeenCalledWith('confirm_window_close', { allow: true });
+  });
+
+  it('asks the user when tabs are dirty and forwards the answer', async () => {
+    const { adapter, fire, invoke } = makeTauri();
+    const confirmDiscard = vi.fn(async () => false);
+
+    await attachWindowCloseConfirm({
+      hasDirtyWork: () => true,
+      confirmDiscard,
+      tauri: adapter
+    });
+
+    await fire();
+
+    expect(confirmDiscard).toHaveBeenCalled();
+    expect(invoke).toHaveBeenCalledWith('confirm_window_close', { allow: false });
+  });
+
+  it('invokes with allow:true when user discards dirty work', async () => {
+    const { adapter, fire, invoke } = makeTauri();
+    await attachWindowCloseConfirm({
+      hasDirtyWork: () => true,
+      confirmDiscard: () => true,
+      tauri: adapter
+    });
+
+    await fire();
+
+    expect(invoke).toHaveBeenCalledWith('confirm_window_close', { allow: true });
+  });
+
+  it('returns an unlisten teardown function', async () => {
+    const { adapter, unlisten } = makeTauri();
+    const teardown = await attachWindowCloseConfirm({
+      hasDirtyWork: () => false,
+      confirmDiscard: () => true,
+      tauri: adapter
+    });
+
+    teardown();
+
+    expect(unlisten).toHaveBeenCalled();
+  });
+
+  it('is a no-op outside of Tauri (no adapter available)', async () => {
+    const teardown = await attachWindowCloseConfirm({
+      hasDirtyWork: () => true,
+      confirmDiscard: () => false,
+      tauri: null
+    });
+
+    // Should not throw, and should return a callable teardown.
+    expect(typeof teardown).toBe('function');
+    teardown();
+  });
+
+  it('swallows invoke errors without throwing into the event loop', async () => {
+    const { adapter, fire, invoke } = makeTauri();
+    invoke.mockRejectedValueOnce(new Error('boom'));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await attachWindowCloseConfirm({
+      hasDirtyWork: () => false,
+      confirmDiscard: () => true,
+      tauri: adapter
+    });
+
+    await fire();
+
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});

--- a/ui/app/src/lib/window-lifecycle.ts
+++ b/ui/app/src/lib/window-lifecycle.ts
@@ -1,0 +1,78 @@
+/**
+ * Window-lifecycle bridge between the Tauri shell and the SvelteKit webview.
+ *
+ * The Tauri close handler (see `crates/notesmith-tauri/src/main.rs`) prevents
+ * the OS close when the red button is clicked and emits a
+ * `notesmith://close-requested` event. The frontend decides whether any
+ * tabs are dirty, asks the user to confirm if so, and reports the answer
+ * back via the `confirm_window_close` command.
+ *
+ * When the page is not running inside Tauri (e.g. dev mode in a browser),
+ * `attachWindowCloseConfirm` becomes a no-op so the webview still works.
+ */
+
+const CLOSE_REQUESTED_EVENT = 'notesmith://close-requested';
+
+export interface CloseConfirmDeps {
+  /** Should return true when the user has any unsaved work. */
+  hasDirtyWork: () => boolean;
+  /** Show a confirmation dialog; resolves to true when the user wants to discard and close. */
+  confirmDiscard: () => Promise<boolean> | boolean;
+  /** Override for tests. Returns true if `__TAURI__` is available. */
+  tauri?: TauriAdapter | null;
+}
+
+export interface TauriAdapter {
+  listen: (event: string, handler: (payload: unknown) => void) => Promise<() => void>;
+  invoke: (cmd: string, args?: Record<string, unknown>) => Promise<unknown>;
+}
+
+/**
+ * Wire the `notesmith://close-requested` listener and return a teardown fn.
+ */
+export async function attachWindowCloseConfirm(
+  deps: CloseConfirmDeps
+): Promise<() => void> {
+  const tauri = deps.tauri ?? resolveTauri();
+  if (!tauri) {
+    return () => {};
+  }
+
+  const unlisten = await tauri.listen(CLOSE_REQUESTED_EVENT, async () => {
+    const allow = deps.hasDirtyWork() ? await deps.confirmDiscard() : true;
+    try {
+      await tauri.invoke('confirm_window_close', { allow });
+    } catch (error) {
+      console.warn('confirm_window_close failed', error);
+    }
+  });
+
+  return unlisten;
+}
+
+function resolveTauri(): TauriAdapter | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  const t = (window as unknown as { __TAURI__?: TauriRuntime }).__TAURI__;
+  if (!t?.event?.listen || !t.core?.invoke) {
+    return null;
+  }
+  return {
+    listen: (event, handler) =>
+      t.event!.listen(event, (envelope: { payload: unknown }) => handler(envelope.payload)),
+    invoke: (cmd, args) => t.core!.invoke(cmd, args ?? {})
+  };
+}
+
+interface TauriRuntime {
+  event?: {
+    listen: (
+      event: string,
+      handler: (envelope: { payload: unknown }) => void
+    ) => Promise<() => void>;
+  };
+  core?: {
+    invoke: (cmd: string, args: Record<string, unknown>) => Promise<unknown>;
+  };
+}


### PR DESCRIPTION
Implements #105 — the persistence + close-semantics slice of the multi-vault project.

Stacked on top of PR #107 (#104). Set merge base back to `main` once #107 lands.

## Acceptance criteria coverage

### Persistence
- ✅ `windows.json` at `app_config_dir()/windows.json`.
- ✅ Schema `{ version: 1, windows: [{ vault, x, y, w, h }] }`. `last_note` deferred per the issue.
- ✅ Atomic write (`.tmp` + rename) on create, geometry change (debounced 500 ms), real close, and `ExitRequested`.
- ✅ Read in `initialize_app` → `restore_windows_from_disk` → per-entry `ensure_vault_window_with_geometry` with monitor-bounds clamp.
- ✅ Empty / missing / corrupt → fall back to default-vault flow.

### Close semantics
- ✅ `CloseRequested` for `main:*` → `api.prevent_close()` + emit `notesmith://close-requested`.
- ✅ `confirm_window_close(allow)` Tauri command: `true` → mark approved, remove from `VaultWindows`, `window.close()` (re-enters `CloseRequested`, marker found, OS closes), persist; `false` → no-op.
- ✅ Frontend listener (`ui/app/src/lib/window-lifecycle.ts`) checks `tabStore.tabs.some(t => t.dirty)` and shows a `window.confirm` dialog. No-op outside Tauri.
- ✅ Closing the last window does not quit the app.

### CLI
- ✅ `--no-restore` parsed in `initialize_app`; `windows.json` is kept on disk but ignored for this launch. Documented in `docs/cli.md`.

### Tests + validation
- ✅ `windows_persist` unit tests (14): round-trip, missing/empty/corrupt/unknown-version recovery, atomic-write semantics, dedupe, four clamp scenarios.
- ✅ Vitest for the close-confirm listener (6): dirty/clean dispatch, allow/deny forwarding, teardown, no-Tauri no-op, invoke error swallowing.
- ✅ `cd crates/notesmith-tauri && cargo clippy -- -D warnings && cargo test && cargo fmt -- --check` (42 + 7 = 49 tests).
- ✅ `cd ui/app && npm run check && npx vitest run && npm run build` (142 tests, 0 errors).
- ⏳ Manual smoke: requires multi-vault test fixtures + 2 monitors; verified at the unit level.

## Architectural notes
- Added `capabilities/vault-windows.json` matching the `main:*` glob so vault webviews can call `__TAURI__` (`core:default` was previously restricted to `main`/`splash`/`fallback`).
- Flipped `withGlobalTauri` to `true` so the daemon-hosted frontend can use `window.__TAURI__` without an `@tauri-apps/api` npm dep.

Closes #105.