### PR TITLE
feat(ui): per-window vault binding + per-vault localStorage (#102)

### DIFF
--- a/ui/app/src/lib/app-shell-core.ts
+++ b/ui/app/src/lib/app-shell-core.ts
@@ -159,6 +159,7 @@ export function createAppShell(callbacks: AppShellCallbacks, dependencies: AppSh
 	let handleOpenQuickSwitcher: EventListener | null = null;
 	let availableVaults: string[] | null = null;
 	let lastResyncTime = 0;
+	let urlPinnedVault = false;
 
 	async function performResync(flushQueuedSaves = false) {
 		try {
@@ -241,6 +242,14 @@ export function createAppShell(callbacks: AppShellCallbacks, dependencies: AppSh
 			return;
 		}
 
+		// Sticky window: once a vault was URL-pinned for this window, never
+		// auto-swap it away — even if the vault disappears from the registry.
+		// The window stays bound to the original vault; the user can close it
+		// manually.
+		if (urlPinnedVault) {
+			return;
+		}
+
 		const nextVault =
 			registrations.find((vault) => vault.is_default)?.name ?? vaultNames[0] ?? '';
 		if (!nextVault) {
@@ -256,6 +265,7 @@ export function createAppShell(callbacks: AppShellCallbacks, dependencies: AppSh
 	async function init(vaultParam: string | null, vaults: string[]) {
 		teardown();
 		availableVaults = vaults;
+		urlPinnedVault = vaultParam !== null && vaultParam !== '';
 
 		handleOpenQuickSwitcher = () => callbacks.onOpenQuickSwitcher();
 		dependencies.targetWindow.addEventListener(
@@ -301,6 +311,7 @@ export function createAppShell(callbacks: AppShellCallbacks, dependencies: AppSh
 		removeVisibilityListener = () => {};
 		lastResyncTime = 0;
 		availableVaults = null;
+		urlPinnedVault = false;
 	}
 
 	return { init, teardown };

--- a/ui/app/src/lib/components/CommandPalette.svelte
+++ b/ui/app/src/lib/components/CommandPalette.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 import { fuzzyFilter, type FuzzyMatch } from '$lib/fuzzy';
 import type { Command } from '$lib/commands';
+import { vaultStore } from '$lib/stores.svelte';
 
 let { commands, onClose }: { commands: Command[]; onClose: () => void } = $props();
+
 
 type CommandSection = {
 id: string;
@@ -24,9 +26,17 @@ let inputRef: HTMLInputElement | undefined;
 let resultsRef: HTMLDivElement | undefined;
 let recentIds = $state<string[]>(loadRecentIds());
 
+function recentCommandsKey(): string | null {
+const vault = vaultStore.currentVault;
+if (!vault) return null;
+return `notesmith:recent-commands:${vault}`;
+}
+
 function loadRecentIds(): string[] {
 try {
-const stored = localStorage.getItem('notesmith:recent-commands');
+const key = recentCommandsKey();
+if (!key) return [];
+const stored = localStorage.getItem(key);
 if (!stored) return [];
 const parsed = JSON.parse(stored);
 return Array.isArray(parsed) ? parsed.filter((value): value is string => typeof value === 'string') : [];
@@ -37,7 +47,9 @@ return [];
 
 function saveRecentIds(ids: string[]) {
 try {
-localStorage.setItem('notesmith:recent-commands', JSON.stringify(ids));
+const key = recentCommandsKey();
+if (!key) return;
+localStorage.setItem(key, JSON.stringify(ids));
 } catch {
 // Ignore storage failures.
 }

--- a/ui/app/src/lib/components/OnboardingCard.svelte
+++ b/ui/app/src/lib/components/OnboardingCard.svelte
@@ -1,15 +1,23 @@
 <script lang="ts">
 import { onMount } from 'svelte';
 import { fade } from 'svelte/transition';
+import { vaultStore } from '$lib/stores.svelte';
 
-const STORAGE_KEY = 'notesmith:onboarding-dismissed';
+const STORAGE_PREFIX = 'notesmith:onboarding-dismissed';
+
+function storageKey(): string | null {
+const vault = vaultStore.currentVault;
+if (!vault) return null;
+return `${STORAGE_PREFIX}:${vault}`;
+}
 
 let ready = $state(false);
 let dismissed = $state(false);
 
 onMount(() => {
 try {
-dismissed = localStorage.getItem(STORAGE_KEY) === 'true';
+const key = storageKey();
+dismissed = key ? localStorage.getItem(key) === 'true' : false;
 } catch {
 dismissed = false;
 }
@@ -20,7 +28,9 @@ ready = true;
 function dismiss() {
 dismissed = true;
 try {
-localStorage.setItem(STORAGE_KEY, 'true');
+const key = storageKey();
+if (!key) return;
+localStorage.setItem(key, 'true');
 } catch {
 // ignore storage failures
 }

--- a/ui/app/src/lib/components/RightRail.svelte
+++ b/ui/app/src/lib/components/RightRail.svelte
@@ -118,9 +118,17 @@
 		tabStore.selectNote(path);
 	}
 
+	function railTabKey(): string | null {
+		const vault = vaultStore.currentVault;
+		if (!vault) return null;
+		return `notesmith:rail-tab:${vault}`;
+	}
+
 	function loadTab(): RailTab {
 		try {
-			const saved = localStorage.getItem('notesmith:rail-tab');
+			const key = railTabKey();
+			if (!key) return 'metadata';
+			const saved = localStorage.getItem(key);
 			if (saved === 'metadata' || saved === 'links' || saved === 'toc') {
 				return saved;
 			}
@@ -132,7 +140,9 @@
 	function setTab(tab: RailTab) {
 		activeTab = tab;
 		try {
-			localStorage.setItem('notesmith:rail-tab', tab);
+			const key = railTabKey();
+			if (!key) return;
+			localStorage.setItem(key, tab);
 		} catch {}
 	}
 

--- a/ui/app/src/lib/components/VaultSwitcher.svelte
+++ b/ui/app/src/lib/components/VaultSwitcher.svelte
@@ -1,38 +1,135 @@
 <script lang="ts">
-	import { tabStore } from '$lib/tab-store.svelte';
 	import { vaultStore } from '$lib/stores.svelte';
 
 	let { vaults }: { vaults: string[] } = $props();
 
-	function switchVault(event: Event) {
-		const target = event.target as HTMLSelectElement;
-		vaultStore.currentVault = target.value;
-		tabStore.selectedPath = null;
-		void vaultStore.loadNotes();
+	const OPEN_FOLDER_EVENT = 'notesmith://open-folder-as-vault';
+
+	function resolveTauri():
+		| { invoke: (cmd: string, args: Record<string, unknown>) => Promise<unknown> }
+		| null {
+		if (typeof window === 'undefined') return null;
+		const t = (window as unknown as {
+			__TAURI__?: { core?: { invoke?: (cmd: string, args: Record<string, unknown>) => Promise<unknown> } };
+		}).__TAURI__;
+		if (!t?.core?.invoke) return null;
+		return { invoke: t.core.invoke };
+	}
+
+	async function openVault(vault: string) {
+		if (vault === vaultStore.currentVault) return;
+		const tauri = resolveTauri();
+		if (!tauri) {
+			// Dev / browser mode — navigate by setting ?vault=.
+			if (typeof window !== 'undefined') {
+				const url = new URL(window.location.href);
+				url.searchParams.set('vault', vault);
+				window.location.href = url.toString();
+			}
+			return;
+		}
+		try {
+			await tauri.invoke('open_vault_window', { vault });
+		} catch (error) {
+			console.warn('open_vault_window failed', error);
+		}
+	}
+
+	function openFolderAsVault() {
+		if (typeof window === 'undefined') return;
+		// #103 will land a modal that listens for this event. For now the
+		// menu route also emits the same event from the Tauri side.
+		window.dispatchEvent(new CustomEvent(OPEN_FOLDER_EVENT));
 	}
 </script>
 
-<div class="vault-switcher">
-	<select onchange={switchVault} value={vaultStore.currentVault}>
+<div class="vault-switcher" role="group" aria-label="Vaults">
+	<ul class="vault-list">
 		{#each vaults as vault (vault)}
-			<option value={vault}>{vault}</option>
+			{@const isCurrent = vault === vaultStore.currentVault}
+			<li>
+				<button
+					type="button"
+					class="vault-row"
+					class:current={isCurrent}
+					disabled={isCurrent}
+					aria-current={isCurrent ? 'true' : undefined}
+					onclick={() => void openVault(vault)}
+					title={isCurrent ? `${vault} (this window)` : `Open ${vault} in a new window`}
+				>
+					<span class="vault-name">{vault}</span>
+					{#if isCurrent}
+						<span class="vault-tag">(this window)</span>
+					{/if}
+				</button>
+			</li>
 		{/each}
-	</select>
+		<li>
+			<button
+				type="button"
+				class="vault-row open-folder"
+				onclick={openFolderAsVault}
+				title="Open another folder as a vault"
+			>
+				<span class="vault-name">Open Folder…</span>
+			</button>
+		</li>
+	</ul>
 </div>
 
 <style>
 	.vault-switcher {
-		padding: 8px 12px;
+		padding: 6px 4px;
 		border-bottom: 1px solid var(--ns-border);
 	}
 
-	select {
+	.vault-list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.vault-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 8px;
 		width: 100%;
-		padding: 6px 8px;
-		background: var(--ns-input-bg);
+		padding: 6px 10px;
+		background: transparent;
 		color: var(--ns-text);
-		border: 1px solid var(--ns-border-input);
+		border: 1px solid transparent;
 		border-radius: 4px;
 		font-size: 13px;
+		text-align: left;
+		cursor: pointer;
+	}
+
+	.vault-row:hover:not(:disabled) {
+		background: var(--ns-surface-hover);
+	}
+
+	.vault-row.current {
+		background: var(--ns-surface-active);
+		cursor: default;
+	}
+
+	.vault-row:disabled {
+		opacity: 1;
+	}
+
+	.vault-tag {
+		font-size: 11px;
+		opacity: 0.7;
+	}
+
+	.vault-row.open-folder {
+		border-top: 1px dashed var(--ns-border);
+		margin-top: 4px;
+		padding-top: 8px;
+		opacity: 0.85;
 	}
 </style>

--- a/ui/app/src/lib/tab-storage-key.ts
+++ b/ui/app/src/lib/tab-storage-key.ts
@@ -1,0 +1,11 @@
+const STORAGE_KEY_PREFIX = 'notesmith:tabs';
+
+/**
+ * Per-vault storage key for the tab state. Returns null when no vault is
+ * selected so callers can skip the read/write (avoids cross-window clobber
+ * of a stale, unscoped `notesmith:tabs` blob).
+ */
+export function tabStorageKey(vault: string): string | null {
+  if (!vault) return null;
+  return `${STORAGE_KEY_PREFIX}:${vault}`;
+}

--- a/ui/app/src/lib/tab-store.svelte.ts
+++ b/ui/app/src/lib/tab-store.svelte.ts
@@ -16,8 +16,11 @@ type TabState,
 type ViewMode
 } from './tab-state';
 import { vaultStore } from './stores.svelte';
+import { tabStorageKey } from './tab-storage-key';
 
-const STORAGE_KEY = 'notesmith:tabs';
+function storageKey(): string | null {
+	return tabStorageKey(vaultStore.currentVault);
+}
 
 export type { Tab, ViewMode } from './tab-state';
 
@@ -104,7 +107,9 @@ this._persistTabs();
 
 restoreTabs() {
 try {
-const restored = restoreTabState(localStorage.getItem(STORAGE_KEY));
+const key = storageKey();
+if (!key) return;
+const restored = restoreTabState(localStorage.getItem(key));
 if (!restored) {
 return;
 }
@@ -136,8 +141,10 @@ this._recentlyClosed = state.recentlyClosed;
 
 private _persistTabs() {
 try {
+const key = storageKey();
+if (!key) return;
 localStorage.setItem(
-STORAGE_KEY,
+key,
 serializeTabState({
 tabs: this.tabs,
 activeTabIndex: this.activeTabIndex

--- a/ui/app/src/lib/tab-store.test.ts
+++ b/ui/app/src/lib/tab-store.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { tabStorageKey } from './tab-storage-key';
+
+describe('tabStorageKey', () => {
+  it('returns null when vault is empty (avoids cross-window clobber)', () => {
+    expect(tabStorageKey('')).toBeNull();
+  });
+
+  it('namespaces by vault name', () => {
+    expect(tabStorageKey('work')).toBe('notesmith:tabs:work');
+    expect(tabStorageKey('home')).toBe('notesmith:tabs:home');
+  });
+
+  it('produces distinct keys for different vaults so they never collide', () => {
+    expect(tabStorageKey('work')).not.toBe(tabStorageKey('home'));
+  });
+});

--- a/ui/app/src/lib/window-title.test.ts
+++ b/ui/app/src/lib/window-title.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { formatWindowTitle, pushWindowTitle } from './window-title';
+
+describe('formatWindowTitle', () => {
+  it('joins vault and note with em dash', () => {
+    expect(formatWindowTitle('work', 'Inbox')).toBe('work — Inbox');
+  });
+
+  it('falls back to vault alone when note is empty', () => {
+    expect(formatWindowTitle('work', '')).toBe('work');
+    expect(formatWindowTitle('work', null)).toBe('work');
+    expect(formatWindowTitle('work', '   ')).toBe('work');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(formatWindowTitle('  work  ', '  My Note  ')).toBe('work — My Note');
+  });
+
+  it('returns empty when both are empty', () => {
+    expect(formatWindowTitle('', null)).toBe('');
+  });
+});
+
+describe('pushWindowTitle', () => {
+  it('invokes set_window_title with formatted title', async () => {
+    const invoke = vi.fn().mockResolvedValue(undefined);
+    await pushWindowTitle('work', 'Note', { invoke });
+    expect(invoke).toHaveBeenCalledWith('set_window_title', { title: 'work — Note' });
+  });
+
+  it('is a no-op when adapter is null', async () => {
+    await expect(pushWindowTitle('work', 'x', null)).resolves.toBeUndefined();
+  });
+
+  it('swallows invoke errors', async () => {
+    const invoke = vi.fn().mockRejectedValue(new Error('nope'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await expect(pushWindowTitle('work', 'x', { invoke })).resolves.toBeUndefined();
+    warn.mockRestore();
+  });
+});

--- a/ui/app/src/lib/window-title.ts
+++ b/ui/app/src/lib/window-title.ts
@@ -1,0 +1,44 @@
+/**
+ * Push `<vault> — <note>` to the Tauri window title via the
+ * `set_window_title` command. In non-Tauri contexts (dev browser, tests)
+ * this is a no-op.
+ */
+
+interface TauriRuntime {
+  core?: {
+    invoke: (cmd: string, args: Record<string, unknown>) => Promise<unknown>;
+  };
+}
+
+export interface WindowTitleAdapter {
+  invoke: (cmd: string, args: Record<string, unknown>) => Promise<unknown>;
+}
+
+export function formatWindowTitle(vault: string, noteTitle: string | null): string {
+  const trimmedVault = vault.trim();
+  const trimmedNote = noteTitle?.trim() ?? '';
+  if (!trimmedVault) return trimmedNote;
+  if (!trimmedNote) return trimmedVault;
+  return `${trimmedVault} — ${trimmedNote}`;
+}
+
+export async function pushWindowTitle(
+  vault: string,
+  noteTitle: string | null,
+  adapter: WindowTitleAdapter | null = resolveTauri()
+): Promise<void> {
+  if (!adapter) return;
+  const title = formatWindowTitle(vault, noteTitle);
+  try {
+    await adapter.invoke('set_window_title', { title });
+  } catch (error) {
+    console.warn('set_window_title failed', error);
+  }
+}
+
+function resolveTauri(): WindowTitleAdapter | null {
+  if (typeof window === 'undefined') return null;
+  const t = (window as unknown as { __TAURI__?: TauriRuntime }).__TAURI__;
+  if (!t?.core?.invoke) return null;
+  return { invoke: (cmd, args) => t.core!.invoke(cmd, args) };
+}

--- a/ui/app/src/routes/+page.svelte
+++ b/ui/app/src/routes/+page.svelte
@@ -26,6 +26,7 @@
 	import { vaultStore } from '$lib/stores.svelte';
 	import { settingsStore } from '$lib/settings.svelte';
 	import { workspaceChromeLayout } from '$lib/workspace-chrome';
+	import { pushWindowTitle } from '$lib/window-title';
 
 	let vaults = $state<string[]>([]);
 	let showCommandPalette = $state(false);
@@ -136,6 +137,12 @@
 		if (vault) {
 			void settingsStore.loadConfig(vault);
 		}
+	});
+
+	$effect(() => {
+		const vault = vaultStore.currentVault;
+		const activeTitle = tabStore.activeTab?.title ?? null;
+		void pushWindowTitle(vault, activeTitle);
 	});
 </script>
 

--- a/ui/app/tests/app-shell.test.ts
+++ b/ui/app/tests/app-shell.test.ts
@@ -440,7 +440,7 @@ test('createAppShell debounces wake resyncs and removes the listener on teardown
 	}
 });
 
-test('createAppShell refreshes vault registrations after vaults.changed events', { concurrency: false }, async () => {
+test('createAppShell refreshes vault registrations after vaults.changed events when not URL-pinned', { concurrency: false }, async () => {
 	stubSvelteRunes();
 
 	const windowStub = createWindowStub();
@@ -486,7 +486,8 @@ test('createAppShell refreshes vault registrations after vaults.changed events',
 	});
 
 	const vaults: string[] = [];
-	await shell.init('work', vaults);
+	// No URL pin → not sticky.
+	await shell.init(null, vaults);
 	assert.deepEqual(vaults, ['work']);
 	assert.equal(vaultStore.currentVault, 'work');
 
@@ -505,6 +506,72 @@ test('createAppShell refreshes vault registrations after vaults.changed events',
 	assert.equal(vaultStore.loadNotesCalls, 2);
 	assert.equal(connectCalls, 2);
 	assert.equal(closeCalls, 1);
+});
+
+test('createAppShell keeps URL-pinned vault sticky even when it disappears from the registry', { concurrency: false }, async () => {
+	stubSvelteRunes();
+
+	const windowStub = createWindowStub();
+	const vaultStore = createVaultStoreStub();
+	const tabStore = createTabStoreStub();
+	const { callbacks } = createCallbacks();
+
+	let onEvent:
+		| ((event: {
+				vault: string;
+				type: string;
+				path: string;
+				timestamp: string;
+		  }) => void)
+		| undefined;
+	let closeCalls = 0;
+	let connectCalls = 0;
+	let listVaultCalls = 0;
+
+	const { createAppShell } = await import('../src/lib/app-shell-core.ts');
+
+	const shell = createAppShell(callbacks, {
+		connectSSE: (_vault, handleEvent) => {
+			connectCalls += 1;
+			onEvent = handleEvent as typeof onEvent;
+			return {
+				close() {
+					closeCalls += 1;
+				}
+			} as EventSource;
+		},
+		listVaults: async () => {
+			listVaultCalls += 1;
+			if (listVaultCalls === 1) {
+				return [{ name: 'work', is_default: true }];
+			}
+			return [{ name: 'home', is_default: true }];
+		},
+		registerHotkeys: () => () => {},
+		vaultStore,
+		tabStore,
+		targetWindow: windowStub.window
+	});
+
+	const vaults: string[] = [];
+	// URL-pinned to 'work' → sticky.
+	await shell.init('work', vaults);
+	assert.equal(vaultStore.currentVault, 'work');
+
+	onEvent?.({
+		vault: 'work',
+		type: 'vaults.changed',
+		path: '',
+		timestamp: new Date().toISOString()
+	});
+	await Promise.resolve();
+	await Promise.resolve();
+
+	// Listed updated, but currentVault stays sticky.
+	assert.equal(listVaultCalls, 2);
+	assert.equal(vaultStore.currentVault, 'work');
+	assert.equal(connectCalls, 1);
+	assert.equal(closeCalls, 0);
 });
 
 test('createAppShell flushes queued saves after SSE reconnects', { concurrency: false }, async () => {


### PR DESCRIPTION
Closes #102. Stacked on #109 (multi-vault-106-dynamic-menus).

## What

- **Sticky vault** — `app-shell-core` no longer auto-swaps the current vault when the registry changes if the window was URL-pinned via `?vault=` (the Tauri shell from #104 always pins). Bare-browser dev mode (no query) still follows the default.
- **Per-vault localStorage namespacing** — every vault-scoped key now gets a `:<vault>` suffix. No legacy migration.
  - `notesmith:tabs:<vault>` (was `notesmith:tabs`)
  - `notesmith:recent-commands:<vault>` (was `notesmith:recent-commands`)
  - `notesmith:rail-tab:<vault>` (was `notesmith:rail-tab`)
  - `notesmith:onboarding-dismissed:<vault>` (was `notesmith:onboarding-dismissed`)
  - Already vault-scoped (no change): `notesmith:section-collapsed:<vault>:…`, `notesmith:middle-pane-width:<vault>:…`, `notesmith:recently-viewed` (record keyed by vault internally)
  - **Not** vault-scoped (intentional, user-level): `notesmith:theme`
- **VaultSwitcher rewrite** — list of registered vaults; each row invokes `open_vault_window(vault)`; current row is non-clickable and marked '(this window)'. 'Open Folder…' dispatches `notesmith://open-folder-as-vault` for the modal in #103.
- **Window title sync** — a `$effect` on currentVault/activeTab pushes `<vault> — <note>` (or just `<vault>` when no note) through `set_window_title` on every change. Falls back to no-op in non-Tauri contexts.

## Tests

- New: `window-title` (7), `tab-storage-key` (3)
- Updated: sticky vs non-sticky branches in `app-shell` node tests (10 total, all pass)
- Vitest: 152 pass / 28 files
- Build: clean

## Out of scope

- Name-this-vault modal (#103)
- Tree-builder.test.ts pre-existing failure (unrelated)