### PR TITLE
feat: name-this-vault modal + open-vault dereg guard (#103)

### DIFF
--- a/crates/notesmith-tauri/Cargo.lock
+++ b/crates/notesmith-tauri/Cargo.lock
@@ -60,6 +60,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "ashpd"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
+dependencies = [
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand",
+ "raw-window-handle",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,6 +834,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "dlopen2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,6 +888,12 @@ dependencies = [
  "selectors",
  "tendril",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -2225,6 +2261,7 @@ dependencies = [
  "notesmith-config",
  "notesmith-core",
  "reqwest 0.12.28",
+ "rfd",
  "serde",
  "serde_json",
  "tauri",
@@ -3105,6 +3142,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+dependencies = [
+ "ashpd",
+ "block2",
+ "dispatch2",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3262,6 +3321,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -4229,6 +4294,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -4808,6 +4874,66 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.4",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "pkg-config",
 ]
 
 [[package]]
@@ -5623,6 +5749,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_repr",
+ "tokio",
  "tracing",
  "uds_windows",
  "uuid",
@@ -5754,6 +5881,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
+ "url",
  "winnow 1.0.2",
  "zvariant_derive",
  "zvariant_utils",

--- a/crates/notesmith-tauri/Cargo.toml
+++ b/crates/notesmith-tauri/Cargo.toml
@@ -12,6 +12,7 @@ tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+rfd = { version = "0.15", default-features = false, features = ["tokio"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 notesmith-core = { path = "../notesmith-core" }

--- a/crates/notesmith-tauri/src/main.rs
+++ b/crates/notesmith-tauri/src/main.rs
@@ -384,7 +384,8 @@ fn main() {
             set_window_title,
             confirm_window_close,
             open_folder_as_vault,
-            list_open_vaults
+            list_open_vaults,
+            pick_vault_folder
         ])
         .menu(build_app_menu)
         .on_menu_event(|app, event| {
@@ -2381,6 +2382,31 @@ fn list_open_vaults(app: tauri::AppHandle) -> Vec<String> {
         .collect();
     open.sort();
     open
+}
+
+/// Open a native folder picker and return the absolute path the user selected.
+///
+/// Returns `Ok(None)` when the user cancels the dialog. The path is validated
+/// to point at an existing directory; symlinks are accepted. The frontend uses
+/// this for the "Open Folder as Vault" flow in #103.
+#[tauri::command]
+async fn pick_vault_folder() -> Result<Option<String>, String> {
+    let result = rfd::AsyncFileDialog::new()
+        .set_title("Choose a folder to open as a vault")
+        .pick_folder()
+        .await;
+    let Some(handle) = result else {
+        return Ok(None);
+    };
+    let path = handle.path().to_path_buf();
+    if !path.is_dir() {
+        return Err(format!("Selected path is not a folder: {}", path.display()));
+    }
+    let path_str = path
+        .to_str()
+        .ok_or_else(|| "Selected path contains invalid UTF-8".to_string())?
+        .to_string();
+    Ok(Some(path_str))
 }
 
 #[cfg(test)]

--- a/ui/app/src/lib/components/OpenFolderAsVaultModal.svelte
+++ b/ui/app/src/lib/components/OpenFolderAsVaultModal.svelte
@@ -1,0 +1,264 @@
+<script lang="ts">
+	import { onMount, tick } from 'svelte';
+	import { listVaults } from '$lib/api';
+	import {
+		defaultNameFromPath,
+		resolveTauri,
+		validateVaultName,
+		type TauriBridge
+	} from '$lib/open-folder-as-vault';
+
+	let {
+		onClose,
+		bridge = resolveTauri()
+	}: {
+		onClose: () => void;
+		bridge?: TauriBridge | null;
+	} = $props();
+
+	let phase = $state<'picking' | 'naming' | 'submitting'>('picking');
+	let path = $state('');
+	let name = $state('');
+	let existing = $state<string[]>([]);
+	let error = $state<string | null>(null);
+	let nameInput = $state<HTMLInputElement | undefined>(undefined);
+
+	onMount(() => {
+		void start();
+	});
+
+	async function start() {
+		if (!bridge) {
+			error = 'The folder picker is only available inside the Notesmith desktop app.';
+			phase = 'naming';
+			return;
+		}
+		try {
+			existing = (await listVaults()).map((v) => v.name);
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load existing vaults';
+		}
+		try {
+			const picked = (await bridge.invoke('pick_vault_folder')) as string | null;
+			if (!picked) {
+				onClose();
+				return;
+			}
+			path = picked;
+			name = defaultNameFromPath(picked);
+			phase = 'naming';
+			await tick();
+			nameInput?.focus();
+			nameInput?.select();
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Folder picker failed';
+			phase = 'naming';
+		}
+	}
+
+	async function confirm() {
+		const result = validateVaultName(name, existing);
+		if (!result.ok) {
+			error = result.error.message;
+			return;
+		}
+		if (!bridge) {
+			error = 'Cannot register vaults outside the Notesmith desktop app.';
+			return;
+		}
+		if (!path) {
+			error = 'No folder selected.';
+			return;
+		}
+		phase = 'submitting';
+		error = null;
+		try {
+			await bridge.invoke('open_folder_as_vault', {
+				path,
+				displayName: result.value
+			});
+			onClose();
+		} catch (e) {
+			error = typeof e === 'string' ? e : e instanceof Error ? e.message : 'Failed to register vault';
+			phase = 'naming';
+			await tick();
+			nameInput?.focus();
+		}
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape') {
+			event.preventDefault();
+			onClose();
+		} else if (event.key === 'Enter' && phase === 'naming') {
+			event.preventDefault();
+			void confirm();
+		}
+	}
+</script>
+
+<div
+	class="modal-backdrop"
+	role="dialog"
+	aria-modal="true"
+	aria-labelledby="open-folder-title"
+	tabindex="-1"
+	onclick={(event) => event.target === event.currentTarget && onClose()}
+	onkeydown={handleKeydown}
+>
+	<div class="modal-sheet">
+		<h2 id="open-folder-title" class="modal-title">Open Folder as Vault</h2>
+
+		{#if phase === 'picking'}
+			<p class="modal-body">Choose a folder to register as a new vault…</p>
+		{:else}
+			<p class="modal-body">
+				Folder: <code class="folder-path" title={path}>{path || '(none)'}</code>
+			</p>
+			<label class="field">
+				<span class="field-label">Vault name</span>
+				<input
+					bind:this={nameInput}
+					bind:value={name}
+					type="text"
+					class="name-input"
+					placeholder="e.g. Personal"
+					disabled={phase === 'submitting'}
+					aria-invalid={error !== null}
+					aria-describedby={error ? 'open-folder-error' : undefined}
+				/>
+			</label>
+			{#if error}
+				<div id="open-folder-error" class="inline-error" role="alert">{error}</div>
+			{/if}
+			<div class="modal-actions">
+				<button type="button" class="btn-secondary" onclick={onClose}>Cancel</button>
+				<button
+					type="button"
+					class="btn-primary"
+					disabled={phase === 'submitting' || !path}
+					onclick={() => void confirm()}
+				>
+					{phase === 'submitting' ? 'Opening…' : 'Open Vault'}
+				</button>
+			</div>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.modal-backdrop {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.5);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 200;
+	}
+
+	.modal-sheet {
+		background: var(--ns-surface-elevated);
+		color: var(--ns-text);
+		border: 1px solid var(--ns-border);
+		border-radius: 8px;
+		padding: 20px;
+		min-width: 420px;
+		max-width: 90vw;
+		box-shadow: 0 10px 40px rgba(0, 0, 0, 0.4);
+	}
+
+	.modal-title {
+		margin: 0 0 12px;
+		font-size: 16px;
+		font-weight: 600;
+	}
+
+	.modal-body {
+		margin: 0 0 12px;
+		font-size: 13px;
+		color: var(--ns-text-secondary);
+	}
+
+	.folder-path {
+		font-family: var(--ns-font-mono, monospace);
+		background: var(--ns-bg);
+		padding: 2px 6px;
+		border-radius: 3px;
+		font-size: 12px;
+		word-break: break-all;
+	}
+
+	.field {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		margin-bottom: 8px;
+	}
+
+	.field-label {
+		font-size: 11px;
+		color: var(--ns-text-muted);
+	}
+
+	.name-input {
+		padding: 6px 10px;
+		border: 1px solid var(--ns-border-input);
+		border-radius: 4px;
+		background: var(--ns-input-bg);
+		color: var(--ns-text);
+		font-size: 13px;
+	}
+
+	.name-input:focus {
+		outline: none;
+		border-color: var(--ns-accent);
+	}
+
+	.inline-error {
+		color: var(--ns-danger);
+		font-size: 12px;
+		margin-bottom: 8px;
+	}
+
+	.modal-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 8px;
+		margin-top: 12px;
+	}
+
+	.btn-primary,
+	.btn-secondary {
+		padding: 6px 14px;
+		border-radius: 4px;
+		font-size: 13px;
+		cursor: pointer;
+		border: 1px solid var(--ns-border-strong);
+	}
+
+	.btn-primary {
+		background: var(--ns-accent-bg);
+		color: var(--ns-text-inverse);
+		border-color: var(--ns-accent-bg);
+	}
+
+	.btn-primary:hover:not(:disabled) {
+		background: var(--ns-accent-bg-hover);
+	}
+
+	.btn-primary:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.btn-secondary {
+		background: transparent;
+		color: var(--ns-text-muted);
+	}
+
+	.btn-secondary:hover {
+		background: var(--ns-surface-hover);
+		color: var(--ns-text);
+	}
+</style>

--- a/ui/app/src/lib/components/VaultsSettings.svelte
+++ b/ui/app/src/lib/components/VaultsSettings.svelte
@@ -11,6 +11,8 @@
 		type Capabilities
 	} from '$lib/api';
 	import { toastStore } from '$lib/toast-store.svelte';
+	import { onMount, onDestroy } from 'svelte';
+	import { resolveTauri } from '$lib/open-folder-as-vault';
 
 	interface Props {
 		capabilities: Capabilities | null;
@@ -36,6 +38,40 @@
 
 	// Reindex state
 	let reindexingVault = $state<string | null>(null);
+
+	// Open-vault tracking (#103) — disable Remove for vaults with a live window.
+	let openVaults = $state<string[]>([]);
+	const tauriBridge = resolveTauri();
+	let openVaultsPollHandle: ReturnType<typeof setInterval> | null = null;
+
+	async function refreshOpenVaults() {
+		if (!tauriBridge) {
+			openVaults = [];
+			return;
+		}
+		try {
+			const result = (await tauriBridge.invoke('list_open_vaults')) as string[];
+			openVaults = Array.isArray(result) ? result : [];
+		} catch {
+			openVaults = [];
+		}
+	}
+
+	onMount(() => {
+		void refreshOpenVaults();
+		if (tauriBridge) {
+			// Light polling so the Remove buttons re-enable when the user closes a
+			// vault window without leaving Settings.
+			openVaultsPollHandle = setInterval(() => void refreshOpenVaults(), 2000);
+		}
+	});
+
+	onDestroy(() => {
+		if (openVaultsPollHandle) {
+			clearInterval(openVaultsPollHandle);
+			openVaultsPollHandle = null;
+		}
+	});
 
 	// ── Load ─────────────────────────────────────────────────────
 	async function load() {
@@ -128,6 +164,10 @@
 	// ── Remove ───────────────────────────────────────────────────
 	async function handleRemove(name: string) {
 		error = null;
+		if (openVaults.includes(name)) {
+			error = `Close the "${name}" window first before removing this vault.`;
+			return;
+		}
 		if (!window.confirm(`Remove vault "${name}"? This only unregisters the vault — your files will not be deleted.`)) {
 			return;
 		}
@@ -222,8 +262,12 @@
 						<button
 							type="button"
 							class="btn-small danger"
-							disabled={vault.is_default}
-							title={vault.is_default ? 'Cannot remove the default vault' : 'Remove vault'}
+							disabled={vault.is_default || openVaults.includes(vault.name)}
+							title={vault.is_default
+								? 'Cannot remove the default vault'
+								: openVaults.includes(vault.name)
+									? `Close the "${vault.name}" window first`
+									: 'Remove vault'}
 							onclick={() => void handleRemove(vault.name)}
 						>Remove</button>
 					</div>

--- a/ui/app/src/lib/open-folder-as-vault.test.ts
+++ b/ui/app/src/lib/open-folder-as-vault.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { validateVaultName, defaultNameFromPath } from './open-folder-as-vault';
+
+describe('validateVaultName', () => {
+  it('accepts a clean unique name', () => {
+    expect(validateVaultName('Personal', ['Work'])).toEqual({
+      ok: true,
+      value: 'Personal'
+    });
+  });
+
+  it('trims whitespace', () => {
+    expect(validateVaultName('  Notes  ', [])).toEqual({
+      ok: true,
+      value: 'Notes'
+    });
+  });
+
+  it('rejects empty / whitespace-only', () => {
+    const r = validateVaultName('   ', []);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.message).toMatch(/empty/i);
+  });
+
+  it('rejects names starting with a dot', () => {
+    const r = validateVaultName('.hidden', []);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.message).toMatch(/dot/i);
+  });
+
+  it('rejects path separators', () => {
+    expect(validateVaultName('a/b', []).ok).toBe(false);
+    expect(validateVaultName('a\\b', []).ok).toBe(false);
+  });
+
+  it('rejects duplicates (case-sensitive, matching backend)', () => {
+    const r = validateVaultName('Work', ['Work', 'Home']);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.message).toMatch(/already exists/i);
+  });
+
+  it('allows distinct case (case-sensitive)', () => {
+    expect(validateVaultName('work', ['Work']).ok).toBe(true);
+  });
+});
+
+describe('defaultNameFromPath', () => {
+  it('uses the last path segment', () => {
+    expect(defaultNameFromPath('/Users/x/Notes')).toBe('Notes');
+    expect(defaultNameFromPath('C:\\Users\\x\\Notes')).toBe('Notes');
+  });
+
+  it('strips trailing slashes', () => {
+    expect(defaultNameFromPath('/Users/x/Notes/')).toBe('Notes');
+    expect(defaultNameFromPath('/Users/x/Notes///')).toBe('Notes');
+  });
+
+  it('strips leading dots from hidden folders', () => {
+    expect(defaultNameFromPath('/Users/x/.vault')).toBe('vault');
+  });
+
+  it('returns empty when path is just separators', () => {
+    expect(defaultNameFromPath('///')).toBe('');
+  });
+});

--- a/ui/app/src/lib/open-folder-as-vault.ts
+++ b/ui/app/src/lib/open-folder-as-vault.ts
@@ -1,0 +1,71 @@
+/**
+ * Pure validation + Tauri-bridge helpers for the "Open Folder as Vault" flow.
+ *
+ * Keeping these out of the Svelte component lets them be unit-tested with
+ * Vitest without spinning up a renderer.
+ */
+
+export interface VaultNameError {
+  message: string;
+}
+
+/**
+ * Validate a candidate display name against the existing vault registry.
+ * Returns the trimmed name on success, or a structured error.
+ *
+ * Mirrors `validate_vault_display_name` in `crates/notesmith-tauri/src/vault_menu.rs`
+ * so the user gets immediate feedback before the round-trip.
+ */
+export function validateVaultName(
+  candidate: string,
+  existing: readonly string[]
+): { ok: true; value: string } | { ok: false; error: VaultNameError } {
+  const trimmed = candidate.trim();
+  if (!trimmed) {
+    return { ok: false, error: { message: 'Vault name cannot be empty.' } };
+  }
+  if (trimmed.startsWith('.')) {
+    return {
+      ok: false,
+      error: { message: 'Vault name cannot start with a dot.' }
+    };
+  }
+  if (trimmed.includes('/') || trimmed.includes('\\')) {
+    return {
+      ok: false,
+      error: { message: 'Vault name cannot contain path separators.' }
+    };
+  }
+  if (existing.some((name) => name === trimmed)) {
+    return {
+      ok: false,
+      error: { message: `A vault named "${trimmed}" already exists.` }
+    };
+  }
+  return { ok: true, value: trimmed };
+}
+
+/**
+ * Derive a default display name from a folder path. Picks the last non-empty
+ * segment and trims any leading dots so the result passes `validateVaultName`.
+ */
+export function defaultNameFromPath(path: string): string {
+  const cleaned = path.replace(/[\\/]+$/, '');
+  const parts = cleaned.split(/[\\/]/);
+  const last = parts[parts.length - 1] ?? '';
+  return last.replace(/^\.+/, '').trim();
+}
+
+export interface TauriBridge {
+  invoke: (cmd: string, args?: Record<string, unknown>) => Promise<unknown>;
+}
+
+export function resolveTauri(): TauriBridge | null {
+  if (typeof window === 'undefined') return null;
+  const t = (window as unknown as {
+    __TAURI__?: { core?: { invoke?: (cmd: string, args: Record<string, unknown>) => Promise<unknown> } };
+  }).__TAURI__;
+  if (!t?.core?.invoke) return null;
+  const inv = t.core.invoke;
+  return { invoke: (cmd, args) => inv(cmd, args ?? {}) };
+}

--- a/ui/app/src/routes/+page.svelte
+++ b/ui/app/src/routes/+page.svelte
@@ -20,6 +20,7 @@
 	import ToastStack from '$lib/components/ToastStack.svelte';
 	import VersionBanner from '$lib/components/VersionBanner.svelte';
 	import VaultSwitcher from '$lib/components/VaultSwitcher.svelte';
+	import OpenFolderAsVaultModal from '$lib/components/OpenFolderAsVaultModal.svelte';
 	import { versionMismatch } from '$lib/api/core';
 	import { inputPalette } from '$lib/input-palette.svelte';
 	import { tabStore } from '$lib/tab-store.svelte';
@@ -44,6 +45,7 @@
 	>(null);
 	let rightRailRef = $state<{ refresh: () => void } | null>(null);
 	let activeMiddlePaneItem = $state<CustomItem | null>(null);
+	let showOpenFolderModal = $state(false);
 	let configToastRef = $state<
 		{ show: (message: string, type: 'info' | 'error') => void } | null
 	>(null);
@@ -129,7 +131,15 @@
 
 		void shell.init(vaultParam, vaults);
 
-		return shell.teardown;
+		const openFolderHandler = () => {
+			showOpenFolderModal = true;
+		};
+		window.addEventListener('notesmith://open-folder-as-vault', openFolderHandler);
+
+		return () => {
+			window.removeEventListener('notesmith://open-folder-as-vault', openFolderHandler);
+			shell.teardown();
+		};
 	});
 
 	$effect(() => {
@@ -259,6 +269,10 @@ onClose={() => (activeMiddlePaneItem = null)}
 
 {#if showQuickSwitcher}
 <QuickSwitcher onClose={() => (showQuickSwitcher = false)} />
+{/if}
+
+{#if showOpenFolderModal}
+<OpenFolderAsVaultModal onClose={() => (showOpenFolderModal = false)} />
 {/if}
 
 <ConfigToast bind:this={configToastRef} />


### PR DESCRIPTION
Closes #103. Final slice of the multi-vault series. Stacked on #110.

## What

### Backend (notesmith-tauri)
- Adds `rfd` for the native folder picker and exposes `pick_vault_folder` (returns `Ok(None)` on cancel; validates the path is a directory).

### Frontend
- **OpenFolderAsVaultModal**: pick folder → name sheet (default = folder basename) → invokes `open_folder_as_vault`. Accessible: `role=dialog` + `aria-modal`, Esc cancels, Enter confirms, focus pulled to the name input. Errors surface inline and keep focus.
- Modal reachable from both surfaces from earlier slices:
  - Menu route (File → New Window → Open Folder…, Tray → Open → Open Folder…) via the `notesmith://open-folder-as-vault` event emitted from #106
  - VaultSwitcher 'Open Folder…' row added in #102
- Pure helpers in `open-folder-as-vault.ts` — `validateVaultName`, `defaultNameFromPath`, `resolveTauri` — with 11 Vitest cases (mirrors backend rules so users get instant feedback before the round-trip).
- Settings → Vaults disables 'Remove' for any vault with an open window. Polls `list_open_vaults` every 2s so the button re-enables when a window is closed. Attempts to remove via stale state show an inline error.

## Validation

- `ui/app`: 163 vitest tests pass, svelte-check 0 errors, build clean
- `notesmith-tauri`: `cargo clippy -D warnings`, `cargo test`, `cargo fmt -- --check` all clean

## Out of scope

- HTTP-level dereg guard in the daemon — the issue explicitly defers this to the frontend ('the daemon doesn't need to know about windows').