### PR TITLE
fix(tauri): vault window close button now actually closes (regression from #105)

### DIFF
--- a/crates/notesmith-tauri/Cargo.lock
+++ b/crates/notesmith-tauri/Cargo.lock
@@ -60,6 +60,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "ashpd"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
+dependencies = [
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand",
+ "raw-window-handle",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,6 +834,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "dlopen2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,6 +888,12 @@ dependencies = [
  "selectors",
  "tendril",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -2225,6 +2261,7 @@ dependencies = [
  "notesmith-config",
  "notesmith-core",
  "reqwest 0.12.28",
+ "rfd",
  "serde",
  "serde_json",
  "tauri",
@@ -3105,6 +3142,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+dependencies = [
+ "ashpd",
+ "block2",
+ "dispatch2",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3262,6 +3321,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -4229,6 +4294,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -4808,6 +4874,66 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.4",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "pkg-config",
 ]
 
 [[package]]
@@ -5623,6 +5749,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_repr",
+ "tokio",
  "tracing",
  "uds_windows",
  "uuid",
@@ -5754,6 +5881,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
+ "url",
  "winnow 1.0.2",
  "zvariant_derive",
  "zvariant_utils",

--- a/crates/notesmith-tauri/Cargo.toml
+++ b/crates/notesmith-tauri/Cargo.toml
@@ -12,6 +12,7 @@ tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+rfd = { version = "0.15", default-features = false, features = ["tokio"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 notesmith-core = { path = "../notesmith-core" }

--- a/crates/notesmith-tauri/capabilities/vault-windows.json
+++ b/crates/notesmith-tauri/capabilities/vault-windows.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri/schema.json",
+  "identifier": "vault-windows",
+  "description": "Capability granted to every per-vault window (main:*).",
+  "windows": ["main:*"],
+  "permissions": [
+    "core:default",
+    "shell:allow-open",
+    "deep-link:default"
+  ]
+}

--- a/crates/notesmith-tauri/src/lib.rs
+++ b/crates/notesmith-tauri/src/lib.rs
@@ -2,3 +2,4 @@
 
 pub mod daemon;
 pub mod vault_window;
+pub mod windows_persist;

--- a/crates/notesmith-tauri/src/lib.rs
+++ b/crates/notesmith-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 //! notesmith-tauri: Thin Tauri v2 desktop shell wrapping the SvelteKit app.
 
 pub mod daemon;
+pub mod vault_menu;
 pub mod vault_window;
 pub mod windows_persist;

--- a/crates/notesmith-tauri/src/main.rs
+++ b/crates/notesmith-tauri/src/main.rs
@@ -384,7 +384,8 @@ fn main() {
             set_window_title,
             confirm_window_close,
             open_folder_as_vault,
-            list_open_vaults
+            list_open_vaults,
+            pick_vault_folder
         ])
         .menu(build_app_menu)
         .on_menu_event(|app, event| {
@@ -2381,6 +2382,31 @@ fn list_open_vaults(app: tauri::AppHandle) -> Vec<String> {
         .collect();
     open.sort();
     open
+}
+
+/// Open a native folder picker and return the absolute path the user selected.
+///
+/// Returns `Ok(None)` when the user cancels the dialog. The path is validated
+/// to point at an existing directory; symlinks are accepted. The frontend uses
+/// this for the "Open Folder as Vault" flow in #103.
+#[tauri::command]
+async fn pick_vault_folder() -> Result<Option<String>, String> {
+    let result = rfd::AsyncFileDialog::new()
+        .set_title("Choose a folder to open as a vault")
+        .pick_folder()
+        .await;
+    let Some(handle) = result else {
+        return Ok(None);
+    };
+    let path = handle.path().to_path_buf();
+    if !path.is_dir() {
+        return Err(format!("Selected path is not a folder: {}", path.display()));
+    }
+    let path_str = path
+        .to_str()
+        .ok_or_else(|| "Selected path contains invalid UTF-8".to_string())?
+        .to_string();
+    Ok(Some(path_str))
 }
 
 #[cfg(test)]

--- a/crates/notesmith-tauri/src/main.rs
+++ b/crates/notesmith-tauri/src/main.rs
@@ -21,7 +21,7 @@ use notesmith_tauri::windows_persist::{
     self, Rect, WindowEntry, WindowsFile, dedupe_latest_per_vault,
 };
 use tauri::{
-    AppHandle, Emitter, Manager, RunEvent, Runtime, UriSchemeContext, Url, WebviewUrl,
+    AppHandle, Emitter, EventTarget, Manager, RunEvent, Runtime, UriSchemeContext, Url, WebviewUrl,
     WebviewWindowBuilder,
     menu::{Menu, MenuItem, PredefinedMenuItem, Submenu},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
@@ -333,29 +333,6 @@ impl WindowsPersistState {
     }
 }
 
-/// Set of window labels that have been approved by the webview for a real
-/// close. The close handler in `on_window_event` checks this set: if present,
-/// it lets the OS close the window; otherwise it prevents the close and asks
-/// the webview to confirm via `CLOSE_REQUESTED_EVENT`.
-#[derive(Default)]
-struct PendingCloses(Mutex<std::collections::HashSet<String>>);
-
-impl PendingCloses {
-    fn allow(&self, label: &str) {
-        self.0
-            .lock()
-            .expect("pending closes poisoned")
-            .insert(label.to_string());
-    }
-
-    fn take(&self, label: &str) -> bool {
-        self.0
-            .lock()
-            .expect("pending closes poisoned")
-            .remove(label)
-    }
-}
-
 fn main() {
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_deep_link::init())
@@ -367,7 +344,6 @@ fn main() {
         .manage(DaemonProcessState::default())
         .manage(VaultWindows::default())
         .manage(WindowsPersistState::default())
-        .manage(PendingCloses::default())
         .manage(InternalHtmlState(Mutex::new(InternalPages {
             fallback: None,
         })))
@@ -413,17 +389,25 @@ fn main() {
                         api.prevent_close();
                         let _ = window.hide();
                     } else if is_vault_window_label(&label) {
-                        let app = window.app_handle();
-                        if app.state::<PendingCloses>().take(&label) {
-                            // Webview already confirmed; let the OS close it.
-                            handle_vault_window_destroyed(app, &label);
-                        } else {
-                            // Ask the webview to confirm. If no listener is
-                            // attached, the close request silently sticks —
-                            // user can close again to force.
-                            api.prevent_close();
-                            let _ = window.emit(CLOSE_REQUESTED_EVENT, label.clone());
-                        }
+                        // Ask only this window's webview to confirm; if it
+                        // says yes it will invoke `confirm_window_close`,
+                        // which destroys the window (no second round trip
+                        // through this handler). If no listener is attached
+                        // the close request silently sticks — the user can
+                        // close again, but this should not happen in
+                        // practice because the listener is registered at
+                        // window mount.
+                        api.prevent_close();
+                        let _ = window.app_handle().emit_to(
+                            EventTarget::webview_window(&label),
+                            CLOSE_REQUESTED_EVENT,
+                            label.clone(),
+                        );
+                    }
+                }
+                tauri::WindowEvent::Destroyed => {
+                    if is_vault_window_label(&label) {
+                        handle_vault_window_destroyed(window.app_handle(), &label);
                     }
                 }
                 tauri::WindowEvent::Moved(_) | tauri::WindowEvent::Resized(_) => {
@@ -2232,11 +2216,10 @@ fn set_window_title(window: tauri::Window, title: String) -> Result<(), String> 
 /// Webview response to a `notesmith://close-requested` event.
 ///
 /// - `allow=true`: the webview has saved/discarded any dirty content and is
-///   ready to be torn down. We mark the window as approved-for-close, remove
-///   the vault binding, then close the window. Closing the window fires
-///   `CloseRequested` again, which finds the marker and lets the OS proceed.
-/// - `allow=false`: the user cancelled; clear nothing extra (no marker was
-///   set) and leave the window where it is.
+///   ready to be torn down. We remove the vault binding then destroy the
+///   window. `destroy()` skips the close handler entirely so there is no
+///   second round trip through `CloseRequested`.
+/// - `allow=false`: the user cancelled; leave the window where it is.
 #[tauri::command]
 async fn confirm_window_close(
     app: tauri::AppHandle,
@@ -2250,18 +2233,12 @@ async fn confirm_window_close(
     if !allow {
         return Ok(());
     }
-    app.state::<PendingCloses>().allow(&label);
 
-    // Remove from VaultWindows now so any focus-existing lookup in the brief
-    // window between this call and the OS destroying the window opens a new
-    // window instead of pointing at a soon-to-be-dead one.
-    app.state::<VaultWindows>().remove_label(&label);
-
+    // VaultWindows entry + windows.json are cleaned up by the
+    // `WindowEvent::Destroyed` handler once destroy() takes effect.
     if let Some(webview) = app.get_webview_window(&label) {
-        webview.close().map_err(|error| error.to_string())?;
+        webview.destroy().map_err(|error| error.to_string())?;
     }
-    // Geometry has been removed; rewrite windows.json.
-    schedule_persist(&app);
     Ok(())
 }
 

--- a/crates/notesmith-tauri/src/main.rs
+++ b/crates/notesmith-tauri/src/main.rs
@@ -13,8 +13,12 @@ use std::time::{Duration, Instant};
 
 use notesmith_tauri::daemon::{self, DaemonSettings, DaemonState, DynError};
 use notesmith_tauri::vault_window::{is_vault_window_label, vault_app_url, vault_window_label};
+use notesmith_tauri::windows_persist::{
+    self, Rect, WindowEntry, WindowsFile, dedupe_latest_per_vault,
+};
 use tauri::{
-    AppHandle, Manager, RunEvent, Runtime, UriSchemeContext, Url, WebviewUrl, WebviewWindowBuilder,
+    AppHandle, Emitter, Manager, RunEvent, Runtime, UriSchemeContext, Url, WebviewUrl,
+    WebviewWindowBuilder,
     menu::{Menu, MenuItem, PredefinedMenuItem, Submenu},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
 };
@@ -41,6 +45,17 @@ const DAEMON_CRASH_WINDOW: Duration = Duration::from_secs(60);
 const DAEMON_CRASH_THRESHOLD: usize = 2;
 const DAEMON_CRASH_LOG_LINES: usize = 200;
 const QUIT_CONFIRM_WINDOW: Duration = Duration::from_secs(5);
+
+/// Debounce window-geometry writes so a drag doesn't trigger hundreds of
+/// `windows.json` rewrites.
+const WINDOWS_PERSIST_DEBOUNCE: Duration = Duration::from_millis(500);
+
+/// CLI flag that suppresses `windows.json` replay for one launch.
+const NO_RESTORE_FLAG: &str = "--no-restore";
+
+/// Frontend event emitted when the user clicks the OS close button. The
+/// webview must respond by invoking `confirm_window_close`.
+const CLOSE_REQUESTED_EVENT: &str = "notesmith://close-requested";
 
 #[derive(Default)]
 struct ExitState(AtomicBool);
@@ -222,9 +237,8 @@ impl Default for DaemonUrlState {
 ///
 /// Used to implement focus-existing: opening a vault that already has a window
 /// re-focuses that window rather than creating a duplicate. Entries are added
-/// when [`ensure_vault_window`] creates a window. Entries are **not** removed
-/// on close while #105 (real close semantics) is unimplemented — close still
-/// hides the window today, so the map entry remains valid.
+/// when [`ensure_vault_window`] creates a window and removed when the user
+/// confirms a real close (see [`confirm_window_close`]).
 #[derive(Default)]
 struct VaultWindows(Mutex<HashMap<String, String>>);
 
@@ -243,6 +257,99 @@ impl VaultWindows {
             .expect("vault windows state poisoned")
             .insert(vault, label);
     }
+
+    /// Remove and return the vault associated with the given window label.
+    fn remove_label(&self, label: &str) -> Option<String> {
+        let mut guard = self.0.lock().expect("vault windows state poisoned");
+        let vault = guard
+            .iter()
+            .find_map(|(k, v)| (v == label).then(|| k.clone()))?;
+        guard.remove(&vault);
+        Some(vault)
+    }
+}
+
+/// Tracks the path to `windows.json` plus a debounced timestamp for the next
+/// flush. The timestamp gates noisy geometry-change writes during a drag.
+#[derive(Default)]
+struct WindowsPersistState {
+    inner: Mutex<WindowsPersistInner>,
+}
+
+#[derive(Default)]
+struct WindowsPersistInner {
+    path: Option<PathBuf>,
+    last_write: Option<Instant>,
+    /// Whether this launch should ignore an existing `windows.json` (the
+    /// file itself stays on disk; we just skip the replay).
+    no_restore: bool,
+}
+
+impl WindowsPersistState {
+    fn set_path(&self, path: PathBuf) {
+        self.inner.lock().expect("windows persist poisoned").path = Some(path);
+    }
+
+    fn path(&self) -> Option<PathBuf> {
+        self.inner
+            .lock()
+            .expect("windows persist poisoned")
+            .path
+            .clone()
+    }
+
+    fn set_no_restore(&self, value: bool) {
+        self.inner
+            .lock()
+            .expect("windows persist poisoned")
+            .no_restore = value;
+    }
+
+    fn no_restore(&self) -> bool {
+        self.inner
+            .lock()
+            .expect("windows persist poisoned")
+            .no_restore
+    }
+
+    /// Returns true if at least `WINDOWS_PERSIST_DEBOUNCE` has elapsed since
+    /// the last write (or no write has happened yet). Resets the debounce
+    /// clock when it returns `true`.
+    fn try_take_debounce_slot(&self) -> bool {
+        let mut guard = self.inner.lock().expect("windows persist poisoned");
+        let now = Instant::now();
+        let ready = match guard.last_write {
+            Some(prev) => now.duration_since(prev) >= WINDOWS_PERSIST_DEBOUNCE,
+            None => true,
+        };
+        if ready {
+            guard.last_write = Some(now);
+        }
+        ready
+    }
+}
+
+/// Set of window labels that have been approved by the webview for a real
+/// close. The close handler in `on_window_event` checks this set: if present,
+/// it lets the OS close the window; otherwise it prevents the close and asks
+/// the webview to confirm via `CLOSE_REQUESTED_EVENT`.
+#[derive(Default)]
+struct PendingCloses(Mutex<std::collections::HashSet<String>>);
+
+impl PendingCloses {
+    fn allow(&self, label: &str) {
+        self.0
+            .lock()
+            .expect("pending closes poisoned")
+            .insert(label.to_string());
+    }
+
+    fn take(&self, label: &str) -> bool {
+        self.0
+            .lock()
+            .expect("pending closes poisoned")
+            .remove(label)
+    }
 }
 
 fn main() {
@@ -255,6 +362,8 @@ fn main() {
         .manage(DaemonUrlState::default())
         .manage(DaemonProcessState::default())
         .manage(VaultWindows::default())
+        .manage(WindowsPersistState::default())
+        .manage(PendingCloses::default())
         .manage(InternalHtmlState(Mutex::new(InternalPages {
             fallback: None,
         })))
@@ -268,7 +377,8 @@ fn main() {
             view_crash_report,
             restart_daemon_anyway,
             open_vault_window,
-            set_window_title
+            set_window_title,
+            confirm_window_close
         ])
         .menu(build_app_menu)
         .on_menu_event(|app, event| {
@@ -288,12 +398,51 @@ fn main() {
             }
         })
         .on_window_event(|window, event| {
-            let label = window.label();
-            if (label == MAIN_WINDOW_LABEL || is_vault_window_label(label))
-                && let tauri::WindowEvent::CloseRequested { api, .. } = event
-            {
-                api.prevent_close();
-                let _ = window.hide();
+            let label = window.label().to_string();
+            match event {
+                tauri::WindowEvent::CloseRequested { api, .. } => {
+                    if label == MAIN_WINDOW_LABEL {
+                        // Onboarding window: keep legacy hide behaviour.
+                        api.prevent_close();
+                        let _ = window.hide();
+                    } else if is_vault_window_label(&label) {
+                        let app = window.app_handle();
+                        if app.state::<PendingCloses>().take(&label) {
+                            // Webview already confirmed; let the OS close it.
+                            handle_vault_window_destroyed(app, &label);
+                        } else {
+                            // Ask the webview to confirm. If no listener is
+                            // attached, the close request silently sticks —
+                            // user can close again to force.
+                            api.prevent_close();
+                            let _ = window.emit(CLOSE_REQUESTED_EVENT, label.clone());
+                        }
+                    }
+                }
+                tauri::WindowEvent::Moved(_) | tauri::WindowEvent::Resized(_) => {
+                    if is_vault_window_label(&label) {
+                        let app = window.app_handle().clone();
+                        let label = label.clone();
+                        // Debounce in-process: only one writer wins per slot.
+                        if app
+                            .state::<WindowsPersistState>()
+                            .try_take_debounce_slot()
+                        {
+                            tauri::async_runtime::spawn(async move {
+                                tauri::async_runtime::spawn_blocking(move || {
+                                    if let Err(error) = persist_open_windows(&app) {
+                                        tracing::warn!(
+                                            "failed to persist windows after geometry change ({label}): {error}"
+                                        );
+                                    }
+                                })
+                                .await
+                                .ok();
+                            });
+                        }
+                    }
+                }
+                _ => {}
             }
         })
         .setup(|app| {
@@ -309,16 +458,41 @@ fn main() {
         {
             api.prevent_exit();
         }
+        RunEvent::ExitRequested { .. } => {
+            // Last chance to flush persistence before the process exits.
+            if let Err(error) = persist_open_windows(app_handle) {
+                tracing::warn!("failed to flush windows.json on exit: {error}");
+            }
+        }
         RunEvent::Resumed => emit_wake_event(app_handle),
         _ => {}
     });
 }
 
 fn initialize_app(app: &tauri::App) -> Result<(), DynError> {
-    show_splash_window(app.handle())?;
-    setup_tray(app.handle())?;
-    setup_deep_links(app.handle())?;
-    tauri::async_runtime::block_on(run_startup_flow(app.handle()))?;
+    let handle = app.handle();
+
+    // Configure persistence path and the --no-restore CLI flag before any
+    // window-event handler fires.
+    if let Ok(config_dir) = handle.path().app_config_dir() {
+        handle
+            .state::<WindowsPersistState>()
+            .set_path(windows_persist::windows_file_path(&config_dir));
+    } else {
+        tracing::warn!("app config dir unavailable; windows.json will not be persisted");
+    }
+    let no_restore = std::env::args().any(|arg| arg == NO_RESTORE_FLAG);
+    handle
+        .state::<WindowsPersistState>()
+        .set_no_restore(no_restore);
+    if no_restore {
+        tracing::info!("{NO_RESTORE_FLAG} detected; skipping windows.json replay this launch");
+    }
+
+    show_splash_window(handle)?;
+    setup_tray(handle)?;
+    setup_deep_links(handle)?;
+    tauri::async_runtime::block_on(run_startup_flow(handle))?;
     Ok(())
 }
 
@@ -909,7 +1083,183 @@ fn ensure_vault_window<R: Runtime>(app: &AppHandle<R>, vault: &str) -> Result<St
 
     app.state::<VaultWindows>()
         .insert(vault.to_string(), label.clone());
+
+    // New window — schedule a persistence flush so windows.json reflects it.
+    schedule_persist(app);
+
     Ok(label)
+}
+
+/// Open a vault window and apply the saved geometry from `windows.json`.
+///
+/// Used by the restore-from-disk path. Differs from `ensure_vault_window` in
+/// that it positions/sizes the new window after creation. Existing windows
+/// are left untouched (we don't overwrite the user's current geometry).
+fn ensure_vault_window_with_geometry<R: Runtime>(
+    app: &AppHandle<R>,
+    vault: &str,
+    entry: &WindowEntry,
+) -> Result<String, DynError> {
+    let label = ensure_vault_window(app, vault)?;
+    if let Some(window) = app.get_webview_window(&label) {
+        // Clamp to a visible monitor so windows from a now-disconnected
+        // display don't end up off-screen.
+        let rect = clamp_to_visible_monitors(&window, entry);
+        let _ = window.set_position(tauri::PhysicalPosition {
+            x: rect.x,
+            y: rect.y,
+        });
+        let _ = window.set_size(tauri::PhysicalSize {
+            width: rect.w,
+            height: rect.h,
+        });
+    }
+    Ok(label)
+}
+
+fn clamp_to_visible_monitors<R: Runtime>(
+    window: &tauri::WebviewWindow<R>,
+    entry: &WindowEntry,
+) -> Rect {
+    let monitors = window
+        .available_monitors()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|m| {
+            let pos = m.position();
+            let size = m.size();
+            Rect {
+                x: pos.x,
+                y: pos.y,
+                w: size.width,
+                h: size.height,
+            }
+        })
+        .collect::<Vec<_>>();
+    windows_persist::clamp_to_monitor(
+        Rect {
+            x: entry.x,
+            y: entry.y,
+            w: entry.w,
+            h: entry.h,
+        },
+        &monitors,
+    )
+}
+
+/// Snapshot the open vault windows and write `windows.json` atomically.
+///
+/// Skipped silently when the persistence path hasn't been configured (e.g.
+/// the app_config_dir lookup failed at startup).
+fn persist_open_windows<R: Runtime>(app: &AppHandle<R>) -> io::Result<()> {
+    let Some(path) = app.state::<WindowsPersistState>().path() else {
+        return Ok(());
+    };
+
+    let entries = snapshot_window_entries(app);
+    let file = WindowsFile {
+        version: windows_persist::SCHEMA_VERSION,
+        windows: dedupe_latest_per_vault(entries),
+    };
+    windows_persist::save(&path, &file)
+}
+
+fn snapshot_window_entries<R: Runtime>(app: &AppHandle<R>) -> Vec<WindowEntry> {
+    let mapping: Vec<(String, String)> = app
+        .state::<VaultWindows>()
+        .0
+        .lock()
+        .expect("vault windows state poisoned")
+        .iter()
+        .map(|(vault, label)| (vault.clone(), label.clone()))
+        .collect();
+
+    let mut out = Vec::with_capacity(mapping.len());
+    for (vault, label) in mapping {
+        let Some(window) = app.get_webview_window(&label) else {
+            continue;
+        };
+        let pos = match window.outer_position() {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        let size = match window.outer_size() {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        out.push(WindowEntry {
+            vault,
+            x: pos.x,
+            y: pos.y,
+            w: size.width,
+            h: size.height,
+        });
+    }
+    out
+}
+
+/// Spawn a non-blocking persistence flush.
+fn schedule_persist<R: Runtime>(app: &AppHandle<R>) {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        tauri::async_runtime::spawn_blocking(move || {
+            if let Err(error) = persist_open_windows(&app) {
+                tracing::warn!("failed to persist windows.json: {error}");
+            }
+        })
+        .await
+        .ok();
+    });
+}
+
+/// Called after a vault window has actually closed.
+///
+/// Removes the entry from [`VaultWindows`] and rewrites `windows.json` so a
+/// subsequent launch doesn't reopen the closed window.
+fn handle_vault_window_destroyed<R: Runtime>(app: &AppHandle<R>, label: &str) {
+    app.state::<VaultWindows>().remove_label(label);
+    schedule_persist(app);
+}
+
+/// Replay `windows.json` and open one window per saved entry.
+///
+/// Returns the number of windows opened (0 when the file is missing, empty,
+/// corrupt, or when `--no-restore` is in effect).
+fn restore_windows_from_disk<R: Runtime>(app: &AppHandle<R>) -> usize {
+    let state = app.state::<WindowsPersistState>();
+    if state.no_restore() {
+        return 0;
+    }
+    let Some(path) = state.path() else {
+        return 0;
+    };
+    let file = match windows_persist::load(&path) {
+        Ok(Some(file)) => file,
+        Ok(None) => return 0,
+        Err(error) => {
+            tracing::warn!("failed to load windows.json: {error}");
+            return 0;
+        }
+    };
+
+    let mut opened = 0;
+    for entry in &file.windows {
+        match ensure_vault_window_with_geometry(app, &entry.vault, entry) {
+            Ok(label) => {
+                if let Some(window) = app.get_webview_window(&label) {
+                    let _ = window.show();
+                }
+                opened += 1;
+            }
+            Err(error) => {
+                tracing::warn!(
+                    "failed to restore vault window for '{}': {error}",
+                    entry.vault
+                );
+            }
+        }
+    }
+    opened
 }
 
 /// Returns the configured default vault, or the first registered vault when
@@ -963,6 +1313,14 @@ fn show_main_app_window<R: Runtime>(
     close_window(app, FALLBACK_WINDOW_LABEL)?;
     set_current_daemon_url(app, daemon::resolve_daemon_url(settings));
 
+    // First: replay persisted windows so a user who had two vaults open
+    // gets both back. If anything was restored, we're done.
+    if restore_windows_from_disk(app) > 0 {
+        return Ok(());
+    }
+
+    // Otherwise, fall back to opening the default vault (existing behaviour)
+    // or onboarding when no vaults exist.
     match resolve_default_vault() {
         Some(vault) => {
             let label = ensure_vault_window(app, &vault)?;
@@ -1755,6 +2113,42 @@ async fn open_vault_window(app: tauri::AppHandle, vault: String) -> Result<(), S
 #[tauri::command]
 fn set_window_title(window: tauri::Window, title: String) -> Result<(), String> {
     window.set_title(&title).map_err(|error| error.to_string())
+}
+
+/// Webview response to a `notesmith://close-requested` event.
+///
+/// - `allow=true`: the webview has saved/discarded any dirty content and is
+///   ready to be torn down. We mark the window as approved-for-close, remove
+///   the vault binding, then close the window. Closing the window fires
+///   `CloseRequested` again, which finds the marker and lets the OS proceed.
+/// - `allow=false`: the user cancelled; clear nothing extra (no marker was
+///   set) and leave the window where it is.
+#[tauri::command]
+async fn confirm_window_close(
+    app: tauri::AppHandle,
+    window: tauri::Window,
+    allow: bool,
+) -> Result<(), String> {
+    let label = window.label().to_string();
+    if !is_vault_window_label(&label) {
+        return Err(format!("not a vault window: {label}"));
+    }
+    if !allow {
+        return Ok(());
+    }
+    app.state::<PendingCloses>().allow(&label);
+
+    // Remove from VaultWindows now so any focus-existing lookup in the brief
+    // window between this call and the OS destroying the window opens a new
+    // window instead of pointing at a soon-to-be-dead one.
+    app.state::<VaultWindows>().remove_label(&label);
+
+    if let Some(webview) = app.get_webview_window(&label) {
+        webview.close().map_err(|error| error.to_string())?;
+    }
+    // Geometry has been removed; rewrite windows.json.
+    schedule_persist(&app);
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/notesmith-tauri/src/main.rs
+++ b/crates/notesmith-tauri/src/main.rs
@@ -399,7 +399,7 @@ fn main() {
                         // window mount.
                         api.prevent_close();
                         let _ = window.app_handle().emit_to(
-                            EventTarget::webview_window(&label),
+                            EventTarget::labeled(&label),
                             CLOSE_REQUESTED_EVENT,
                             label.clone(),
                         );

--- a/crates/notesmith-tauri/src/main.rs
+++ b/crates/notesmith-tauri/src/main.rs
@@ -12,6 +12,10 @@ use std::sync::{
 use std::time::{Duration, Instant};
 
 use notesmith_tauri::daemon::{self, DaemonSettings, DaemonState, DynError};
+use notesmith_tauri::vault_menu::{
+    OPEN_FOLDER_AS_VAULT_ID, decode_open_vault_id, encode_open_vault_id,
+    validate_vault_display_name,
+};
 use notesmith_tauri::vault_window::{is_vault_window_label, vault_app_url, vault_window_label};
 use notesmith_tauri::windows_persist::{
     self, Rect, WindowEntry, WindowsFile, dedupe_latest_per_vault,
@@ -378,7 +382,9 @@ fn main() {
             restart_daemon_anyway,
             open_vault_window,
             set_window_title,
-            confirm_window_close
+            confirm_window_close,
+            open_folder_as_vault,
+            list_open_vaults
         ])
         .menu(build_app_menu)
         .on_menu_event(|app, event| {
@@ -683,7 +689,14 @@ fn emit_wake_event<R: Runtime>(app: &AppHandle<R>) {
     }
 }
 
+/// Build the system menubar.
+///
+/// The "File" submenu now hosts a dynamic "New Window" submenu listing each
+/// registered vault plus an "Open Folder…" entry, so the user can relaunch
+/// any closed vault window without leaving the menubar.
 fn build_app_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
+    let vaults = registered_vault_names();
+
     let open = MenuItem::with_id(app, MENU_OPEN, "Open Notesmith", true, None::<&str>)?;
     let hide = MenuItem::with_id(app, MENU_HIDE, "Close Window", true, Some("CmdOrCtrl+W"))?;
     let quit = MenuItem::with_id(app, MENU_QUIT, "Quit", true, Some("CmdOrCtrl+Q"))?;
@@ -709,6 +722,13 @@ fn build_app_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
 
     let app_submenu =
         Submenu::with_items(app, "Notesmith", true, &[&open, &separator, &hide, &quit])?;
+
+    let new_window_items = build_new_window_submenu_items(app, &vaults)?;
+    let new_window_refs: Vec<&dyn tauri::menu::IsMenuItem<R>> =
+        new_window_items.iter().map(|item| item.as_ref()).collect();
+    let new_window_submenu = Submenu::with_items(app, "New Window", true, &new_window_refs)?;
+    let file_submenu = Submenu::with_items(app, "File", true, &[&new_window_submenu])?;
+
     let edit_submenu = Submenu::with_items(app, "Edit", true, &[&copy, &paste, &select_all])?;
     let diagnostics_submenu = Submenu::with_items(
         app,
@@ -717,11 +737,25 @@ fn build_app_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
         &[&restart_service, &stop_service, &view_logs],
     )?;
 
-    Menu::with_items(app, &[&app_submenu, &edit_submenu, &diagnostics_submenu])
+    Menu::with_items(
+        app,
+        &[
+            &app_submenu,
+            &file_submenu,
+            &edit_submenu,
+            &diagnostics_submenu,
+        ],
+    )
 }
 
-fn setup_tray<R: Runtime>(app: &AppHandle<R>) -> Result<(), DynError> {
-    let open = MenuItem::with_id(app, MENU_OPEN, "Open Notesmith", true, None::<&str>)?;
+fn build_tray_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
+    let vaults = registered_vault_names();
+
+    let open_items = build_new_window_submenu_items(app, &vaults)?;
+    let open_refs: Vec<&dyn tauri::menu::IsMenuItem<R>> =
+        open_items.iter().map(|item| item.as_ref()).collect();
+    let open_submenu = Submenu::with_items(app, "Open", true, &open_refs)?;
+
     let restart_service = MenuItem::with_id(
         app,
         MENU_RESTART_SERVICE,
@@ -735,10 +769,11 @@ fn setup_tray<R: Runtime>(app: &AppHandle<R>) -> Result<(), DynError> {
     let quit_app = MenuItem::with_id(app, MENU_QUIT_APP, "Quit Notesmith", true, None::<&str>)?;
     let separator1 = PredefinedMenuItem::separator(app)?;
     let separator2 = PredefinedMenuItem::separator(app)?;
-    let tray_menu = Menu::with_items(
+
+    Menu::with_items(
         app,
         &[
-            &open,
+            &open_submenu,
             &separator1,
             &restart_service,
             &stop_service,
@@ -746,7 +781,41 @@ fn setup_tray<R: Runtime>(app: &AppHandle<R>) -> Result<(), DynError> {
             &separator2,
             &quit_app,
         ],
-    )?;
+    )
+}
+
+/// Build the menu items that make up the "Open" / "New Window" submenu
+/// (vault entries + separator + "Open Folder…") as a heap-allocated vec so
+/// the caller can recombine them however it wants.
+fn build_new_window_submenu_items<R: Runtime>(
+    app: &AppHandle<R>,
+    vaults: &[String],
+) -> tauri::Result<Vec<Box<dyn tauri::menu::IsMenuItem<R>>>> {
+    let mut entries: Vec<Box<dyn tauri::menu::IsMenuItem<R>>> = Vec::new();
+    for vault in vaults {
+        entries.push(Box::new(MenuItem::with_id(
+            app,
+            encode_open_vault_id(vault),
+            vault,
+            true,
+            None::<&str>,
+        )?));
+    }
+    if !vaults.is_empty() {
+        entries.push(Box::new(PredefinedMenuItem::separator(app)?));
+    }
+    entries.push(Box::new(MenuItem::with_id(
+        app,
+        OPEN_FOLDER_AS_VAULT_ID,
+        "Open Folder\u{2026}",
+        true,
+        None::<&str>,
+    )?));
+    Ok(entries)
+}
+
+fn setup_tray<R: Runtime>(app: &AppHandle<R>) -> Result<(), DynError> {
+    let tray_menu = build_tray_menu(app)?;
 
     let mut tray = TrayIconBuilder::with_id(TRAY_ID)
         .menu(&tray_menu)
@@ -759,6 +828,30 @@ fn setup_tray<R: Runtime>(app: &AppHandle<R>) -> Result<(), DynError> {
 
     tray.build(app)?;
     Ok(())
+}
+
+/// Rebuild the app + tray menus from the current vault list. Called after
+/// a successful vault registration (and other config changes).
+fn rebuild_dynamic_menus<R: Runtime>(app: &AppHandle<R>) -> Result<(), DynError> {
+    let app_menu = build_app_menu(app)?;
+    app.set_menu(app_menu)?;
+    let tray_menu = build_tray_menu(app)?;
+    if let Some(tray) = app.tray_by_id(TRAY_ID) {
+        tray.set_menu(Some(tray_menu))?;
+    }
+    Ok(())
+}
+
+/// Sorted list of vault names from `GlobalConfig`. Empty when no vaults
+/// are registered or when the config fails to load.
+fn registered_vault_names() -> Vec<String> {
+    match notesmith_config::GlobalConfig::load() {
+        Ok(config) => config.vaults.keys().cloned().collect(),
+        Err(error) => {
+            tracing::warn!("failed to load global config for menu: {error}");
+            Vec::new()
+        }
+    }
 }
 
 fn handle_menu_event<R: Runtime>(app: &AppHandle<R>, id: &str) -> Result<(), DynError> {
@@ -777,6 +870,26 @@ fn handle_menu_event<R: Runtime>(app: &AppHandle<R>, id: &str) -> Result<(), Dyn
         MENU_VIEW_LOGS => open_diagnostics_target(),
         MENU_QUIT_APP => {
             stop_daemon_and_exit(app.clone());
+            Ok(())
+        }
+        OPEN_FOLDER_AS_VAULT_ID => {
+            // Ask the active webview (or any webview) to show its
+            // folder-picker modal. The modal itself ships in #103.
+            for label in all_app_window_labels(app) {
+                if let Some(window) = app.get_webview_window(&label) {
+                    let _ = window.emit("notesmith://open-folder-as-vault", ());
+                }
+            }
+            Ok(())
+        }
+        other if decode_open_vault_id(other).is_some() => {
+            let vault = decode_open_vault_id(other).expect("just checked");
+            let label = ensure_vault_window(app, &vault)?;
+            if let Some(window) = app.get_webview_window(&label) {
+                let _ = window.show();
+                let _ = window.unminimize();
+                let _ = window.set_focus();
+            }
             Ok(())
         }
         _ => Ok(()),
@@ -2149,6 +2262,125 @@ async fn confirm_window_close(
     // Geometry has been removed; rewrite windows.json.
     schedule_persist(&app);
     Ok(())
+}
+
+/// Register a folder as a new vault and immediately open a window for it.
+///
+/// Steps:
+/// 1. Validate the display name client-side (length, characters, uniqueness).
+/// 2. POST to `<daemon>/api/app/vaults` with the path + display name.
+/// 3. Poll `GET /api/app/vaults` until the new vault appears (≤1 s) so the
+///    config-cache is warm before we ask `ensure_vault_window` to open it.
+/// 4. Rebuild the dynamic menus so the new vault shows up immediately.
+/// 5. Open the window.
+#[tauri::command]
+async fn open_folder_as_vault(
+    app: tauri::AppHandle,
+    path: String,
+    display_name: String,
+) -> Result<(), String> {
+    let existing: Vec<String> = notesmith_config::GlobalConfig::load()
+        .map_err(|error| error.to_string())?
+        .vaults
+        .keys()
+        .cloned()
+        .collect();
+    let validated = validate_vault_display_name(&display_name, existing.iter())?;
+
+    let base = current_daemon_url(&app);
+    let url = format!("{}/api/app/vaults", base.trim_end_matches('/'));
+    let body = serde_json::json!({ "name": validated, "path": path });
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|error| format!("Failed to contact Notesmith daemon: {error}"))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let detail = response
+            .json::<serde_json::Value>()
+            .await
+            .ok()
+            .and_then(|value| {
+                value
+                    .get("message")
+                    .and_then(|message| message.as_str().map(str::to_string))
+            })
+            .unwrap_or_else(|| format!("daemon returned status {status}"));
+        return Err(detail);
+    }
+
+    // Wait for the new vault to appear in GET /api/app/vaults so subsequent
+    // window opens see a fully-loaded vault.
+    let list_url = url.clone();
+    let mut attempts = 0u32;
+    loop {
+        attempts += 1;
+        let listed = client
+            .get(&list_url)
+            .send()
+            .await
+            .and_then(|r| r.error_for_status())
+            .map_err(|error| format!("Failed to list vaults after register: {error}"))?
+            .json::<serde_json::Value>()
+            .await
+            .map_err(|error| format!("Failed to parse vault list: {error}"))?;
+
+        let found = listed
+            .as_array()
+            .map(|entries| {
+                entries.iter().any(|entry| {
+                    entry.get("name").and_then(|n| n.as_str()) == Some(validated.as_str())
+                })
+            })
+            .unwrap_or(false);
+
+        if found {
+            break;
+        }
+        if attempts >= 10 {
+            return Err(format!(
+                "Vault '{validated}' was registered but didn't appear in the daemon vault list within 1s"
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    if let Err(error) = rebuild_dynamic_menus(&app) {
+        tracing::warn!("failed to rebuild menus after register: {error}");
+    }
+
+    let label = ensure_vault_window(&app, &validated).map_err(|error| error.to_string())?;
+    if let Some(window) = app.get_webview_window(&label) {
+        let _ = window.show();
+        let _ = window.unminimize();
+        let _ = window.set_focus();
+    }
+
+    Ok(())
+}
+
+/// Return the names of vaults with at least one open window.
+///
+/// Used by the Settings UI in #103 to disable the "Remove vault" button
+/// when the vault is currently open.
+#[tauri::command]
+fn list_open_vaults(app: tauri::AppHandle) -> Vec<String> {
+    let mut open: Vec<String> = app
+        .state::<VaultWindows>()
+        .0
+        .lock()
+        .expect("vault windows state poisoned")
+        .iter()
+        .filter(|(_, label)| app.get_webview_window(label).is_some())
+        .map(|(vault, _)| vault.clone())
+        .collect();
+    open.sort();
+    open
 }
 
 #[cfg(test)]

--- a/crates/notesmith-tauri/src/main.rs
+++ b/crates/notesmith-tauri/src/main.rs
@@ -57,10 +57,6 @@ const WINDOWS_PERSIST_DEBOUNCE: Duration = Duration::from_millis(500);
 /// CLI flag that suppresses `windows.json` replay for one launch.
 const NO_RESTORE_FLAG: &str = "--no-restore";
 
-/// Frontend event emitted when the user clicks the OS close button. The
-/// webview must respond by invoking `confirm_window_close`.
-const CLOSE_REQUESTED_EVENT: &str = "notesmith://close-requested";
-
 #[derive(Default)]
 struct ExitState(AtomicBool);
 
@@ -241,8 +237,8 @@ impl Default for DaemonUrlState {
 ///
 /// Used to implement focus-existing: opening a vault that already has a window
 /// re-focuses that window rather than creating a duplicate. Entries are added
-/// when [`ensure_vault_window`] creates a window and removed when the user
-/// confirms a real close (see [`confirm_window_close`]).
+/// when [`ensure_vault_window`] creates a window and removed when the
+/// `WindowEvent::Destroyed` handler fires.
 #[derive(Default)]
 struct VaultWindows(Mutex<HashMap<String, String>>);
 
@@ -388,15 +384,11 @@ fn main() {
                         // Onboarding window: keep legacy hide behaviour.
                         api.prevent_close();
                         let _ = window.hide();
-                    } else if is_vault_window_label(&label) {
-                        // Broadcast for reliable delivery to daemon-hosted
-                        // webviews; the frontend filters the payload label so
-                        // only the window being closed responds.
-                        api.prevent_close();
-                        let _ = window
-                            .app_handle()
-                            .emit(CLOSE_REQUESTED_EVENT, label.clone());
                     }
+                    // Vault windows: let native close proceed. The
+                    // `Destroyed` handler below cleans up VaultWindows and
+                    // windows.json. Auto-save ensures no more than ~1 s of
+                    // edits can be lost.
                 }
                 tauri::WindowEvent::Destroyed => {
                     if is_vault_window_label(&label) {
@@ -2206,13 +2198,11 @@ fn set_window_title(window: tauri::Window, title: String) -> Result<(), String> 
     window.set_title(&title).map_err(|error| error.to_string())
 }
 
-/// Webview response to a `notesmith://close-requested` event.
+/// Legacy command: webview response to close-requested events.
 ///
-/// - `allow=true`: the webview has saved/discarded any dirty content and is
-///   ready to be torn down. We remove the vault binding then destroy the
-///   window. `destroy()` skips the close handler entirely so there is no
-///   second round trip through `CloseRequested`.
-/// - `allow=false`: the user cancelled; leave the window where it is.
+/// Retained for API compatibility. Vault windows now close natively (the OS
+/// close button is no longer intercepted) and cleanup happens in the
+/// `WindowEvent::Destroyed` handler.
 #[tauri::command]
 async fn confirm_window_close(
     app: tauri::AppHandle,

--- a/crates/notesmith-tauri/src/main.rs
+++ b/crates/notesmith-tauri/src/main.rs
@@ -21,7 +21,7 @@ use notesmith_tauri::windows_persist::{
     self, Rect, WindowEntry, WindowsFile, dedupe_latest_per_vault,
 };
 use tauri::{
-    AppHandle, Emitter, EventTarget, Manager, RunEvent, Runtime, UriSchemeContext, Url, WebviewUrl,
+    AppHandle, Emitter, Manager, RunEvent, Runtime, UriSchemeContext, Url, WebviewUrl,
     WebviewWindowBuilder,
     menu::{Menu, MenuItem, PredefinedMenuItem, Submenu},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
@@ -389,20 +389,13 @@ fn main() {
                         api.prevent_close();
                         let _ = window.hide();
                     } else if is_vault_window_label(&label) {
-                        // Ask only this window's webview to confirm; if it
-                        // says yes it will invoke `confirm_window_close`,
-                        // which destroys the window (no second round trip
-                        // through this handler). If no listener is attached
-                        // the close request silently sticks — the user can
-                        // close again, but this should not happen in
-                        // practice because the listener is registered at
-                        // window mount.
+                        // Broadcast for reliable delivery to daemon-hosted
+                        // webviews; the frontend filters the payload label so
+                        // only the window being closed responds.
                         api.prevent_close();
-                        let _ = window.app_handle().emit_to(
-                            EventTarget::labeled(&label),
-                            CLOSE_REQUESTED_EVENT,
-                            label.clone(),
-                        );
+                        let _ = window
+                            .app_handle()
+                            .emit(CLOSE_REQUESTED_EVENT, label.clone());
                     }
                 }
                 tauri::WindowEvent::Destroyed => {

--- a/crates/notesmith-tauri/src/vault_menu.rs
+++ b/crates/notesmith-tauri/src/vault_menu.rs
@@ -1,0 +1,182 @@
+//! Vault menu helpers: pure functions for menu id encoding and decoding.
+//!
+//! Vault submenu entries live on both the system tray and the application
+//! menu. Their ids encode the vault name so a single `handle_menu_event`
+//! arm can dispatch to `open_vault_window`. We URL-encode the name so
+//! arbitrary unicode and punctuation survive a round-trip through Tauri's
+//! `MenuId` (which is a free-form string but historically picky about
+//! shell-like characters).
+
+/// Prefix for menu ids that open a registered vault.
+pub const OPEN_VAULT_PREFIX: &str = "open_vault::";
+
+/// Menu id for the "Open Folder…" / "Open Folder as Vault…" entry.
+pub const OPEN_FOLDER_AS_VAULT_ID: &str = "open_folder_as_vault";
+
+/// Encode a vault name into a menu id.
+pub fn encode_open_vault_id(vault: &str) -> String {
+    let mut out = String::with_capacity(OPEN_VAULT_PREFIX.len() + vault.len());
+    out.push_str(OPEN_VAULT_PREFIX);
+    for ch in vault.chars() {
+        if is_unreserved(ch) {
+            out.push(ch);
+        } else {
+            let mut buf = [0u8; 4];
+            for byte in ch.encode_utf8(&mut buf).as_bytes() {
+                out.push_str(&format!("%{byte:02X}"));
+            }
+        }
+    }
+    out
+}
+
+/// Reverse of [`encode_open_vault_id`]. Returns `None` for ids that don't
+/// match the prefix or that are malformed.
+pub fn decode_open_vault_id(id: &str) -> Option<String> {
+    let rest = id.strip_prefix(OPEN_VAULT_PREFIX)?;
+    let bytes = rest.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == b'%' {
+            if i + 2 >= bytes.len() {
+                return None;
+            }
+            let hi = hex_value(bytes[i + 1])?;
+            let lo = hex_value(bytes[i + 2])?;
+            out.push((hi << 4) | lo);
+            i += 3;
+        } else {
+            out.push(b);
+            i += 1;
+        }
+    }
+    String::from_utf8(out).ok()
+}
+
+fn is_unreserved(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '~')
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(10 + byte - b'a'),
+        b'A'..=b'F' => Some(10 + byte - b'A'),
+        _ => None,
+    }
+}
+
+/// Validate a user-supplied vault display name for `open_folder_as_vault`.
+///
+/// Returns `Err(message)` for the frontend to surface inline. Rules:
+/// - non-empty after trimming
+/// - no path separators
+/// - no leading dot (avoids hidden-file collisions in any future on-disk
+///   sidecar)
+/// - not in the `existing` set (case-sensitive — matches how
+///   `GlobalConfig::vaults` keys them today)
+pub fn validate_vault_display_name<I, S>(name: &str, existing: I) -> Result<String, String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err("Vault name must not be empty".to_string());
+    }
+    if trimmed.contains('/') || trimmed.contains('\\') {
+        return Err("Vault name must not contain path separators".to_string());
+    }
+    if trimmed.starts_with('.') {
+        return Err("Vault name must not start with '.'".to_string());
+    }
+    for candidate in existing {
+        if candidate.as_ref() == trimmed {
+            return Err(format!("Vault '{trimmed}' is already registered"));
+        }
+    }
+    Ok(trimmed.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_passes_through_unreserved_chars() {
+        assert_eq!(encode_open_vault_id("personal"), "open_vault::personal");
+        assert_eq!(encode_open_vault_id("work-2024"), "open_vault::work-2024");
+    }
+
+    #[test]
+    fn encode_percent_encodes_spaces_and_punctuation() {
+        assert_eq!(encode_open_vault_id("My Notes"), "open_vault::My%20Notes");
+        assert_eq!(encode_open_vault_id("a/b"), "open_vault::a%2Fb");
+    }
+
+    #[test]
+    fn encode_percent_encodes_non_ascii() {
+        assert_eq!(encode_open_vault_id("ñ"), "open_vault::%C3%B1");
+    }
+
+    #[test]
+    fn decode_round_trips_for_ascii() {
+        let id = encode_open_vault_id("personal");
+        assert_eq!(decode_open_vault_id(&id).as_deref(), Some("personal"));
+    }
+
+    #[test]
+    fn decode_round_trips_for_spaces_and_unicode() {
+        for vault in ["My Notes", "ñ", "a/b", "Émojis 🚀", "with:colon"] {
+            let id = encode_open_vault_id(vault);
+            assert_eq!(
+                decode_open_vault_id(&id).as_deref(),
+                Some(vault),
+                "round-trip failed for {vault:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn decode_returns_none_for_non_matching_id() {
+        assert_eq!(decode_open_vault_id("not_a_vault_id"), None);
+        assert_eq!(decode_open_vault_id("open_folder_as_vault"), None);
+        assert_eq!(decode_open_vault_id(""), None);
+    }
+
+    #[test]
+    fn decode_returns_none_for_malformed_percent_escape() {
+        assert_eq!(decode_open_vault_id("open_vault::ab%2"), None);
+        assert_eq!(decode_open_vault_id("open_vault::ab%ZZ"), None);
+    }
+
+    #[test]
+    fn validate_rejects_empty_or_whitespace() {
+        assert!(validate_vault_display_name("", std::iter::empty::<&str>()).is_err());
+        assert!(validate_vault_display_name("   ", std::iter::empty::<&str>()).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_path_separators_and_dotfiles() {
+        assert!(validate_vault_display_name("a/b", std::iter::empty::<&str>()).is_err());
+        assert!(validate_vault_display_name("a\\b", std::iter::empty::<&str>()).is_err());
+        assert!(validate_vault_display_name(".hidden", std::iter::empty::<&str>()).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_duplicates() {
+        let existing = ["personal", "work"];
+        let err = validate_vault_display_name("personal", existing.iter()).unwrap_err();
+        assert!(err.contains("already registered"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_trims_and_returns_normalised_name() {
+        assert_eq!(
+            validate_vault_display_name("  newvault  ", std::iter::empty::<&str>()).unwrap(),
+            "newvault"
+        );
+    }
+}

--- a/crates/notesmith-tauri/src/windows_persist.rs
+++ b/crates/notesmith-tauri/src/windows_persist.rs
@@ -1,0 +1,389 @@
+//! Persistence for the set of open vault windows.
+//!
+//! On every meaningful change (a window opens, moves, resizes, or closes) we
+//! atomically rewrite `windows.json` in the app config directory. On launch we
+//! replay the file to re-open each vault window at its saved geometry.
+//!
+//! All filesystem I/O and the pure geometry helpers (`clamp_to_monitor`,
+//! `dedupe_latest_per_vault`) live here so they can be unit tested without a
+//! running Tauri runtime.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Current schema version. Bump and add a migration when fields change.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// On-disk representation of the open-window set.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WindowsFile {
+    pub version: u32,
+    #[serde(default)]
+    pub windows: Vec<WindowEntry>,
+}
+
+impl Default for WindowsFile {
+    fn default() -> Self {
+        Self {
+            version: SCHEMA_VERSION,
+            windows: Vec::new(),
+        }
+    }
+}
+
+/// One persisted vault window.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WindowEntry {
+    pub vault: String,
+    pub x: i32,
+    pub y: i32,
+    pub w: u32,
+    pub h: u32,
+}
+
+/// Rectangle in screen coordinates. Used for monitor-bounds clamping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Rect {
+    pub x: i32,
+    pub y: i32,
+    pub w: u32,
+    pub h: u32,
+}
+
+/// Return the path to `windows.json` inside the given config directory.
+pub fn windows_file_path(config_dir: &Path) -> PathBuf {
+    config_dir.join("windows.json")
+}
+
+/// Load and parse `windows.json`. Missing, empty, or corrupt files return
+/// `Ok(None)` so the caller can fall back to first-launch flow.
+pub fn load(path: &Path) -> io::Result<Option<WindowsFile>> {
+    let bytes = match fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    if bytes.is_empty() {
+        return Ok(None);
+    }
+    match serde_json::from_slice::<WindowsFile>(&bytes) {
+        Ok(file) if file.version == SCHEMA_VERSION => Ok(Some(file)),
+        _ => Ok(None),
+    }
+}
+
+/// Atomically write `windows.json` by serialising to a sibling `.tmp` file
+/// and renaming. The parent directory must already exist.
+pub fn save(path: &Path, file: &WindowsFile) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let tmp_path = match path.extension() {
+        Some(ext) => {
+            let mut new_ext = ext.to_os_string();
+            new_ext.push(".tmp");
+            path.with_extension(new_ext)
+        }
+        None => path.with_extension("tmp"),
+    };
+    let bytes = serde_json::to_vec_pretty(file)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    fs::write(&tmp_path, bytes)?;
+    fs::rename(&tmp_path, path)?;
+    Ok(())
+}
+
+/// Collapse multiple entries for the same vault, keeping the last one in
+/// document order. The on-disk invariant is "at most one entry per vault".
+pub fn dedupe_latest_per_vault(entries: Vec<WindowEntry>) -> Vec<WindowEntry> {
+    let mut seen: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    let mut result: Vec<WindowEntry> = Vec::with_capacity(entries.len());
+    for entry in entries {
+        if let Some(&index) = seen.get(&entry.vault) {
+            result[index] = entry;
+        } else {
+            seen.insert(entry.vault.clone(), result.len());
+            result.push(entry);
+        }
+    }
+    result
+}
+
+/// Clamp `rect` so that it intersects one of the given `monitors`. If the
+/// rect is fully off-screen (no overlap with any monitor), centre it inside
+/// the first monitor. Returns the (possibly adjusted) rectangle.
+pub fn clamp_to_monitor(rect: Rect, monitors: &[Rect]) -> Rect {
+    if monitors.is_empty() {
+        return rect;
+    }
+
+    if monitors.iter().any(|m| overlaps(rect, *m)) {
+        return rect;
+    }
+
+    let primary = monitors[0];
+    let w = rect.w.min(primary.w);
+    let h = rect.h.min(primary.h);
+    let x = primary.x + ((primary.w.saturating_sub(w)) / 2) as i32;
+    let y = primary.y + ((primary.h.saturating_sub(h)) / 2) as i32;
+    Rect { x, y, w, h }
+}
+
+fn overlaps(a: Rect, b: Rect) -> bool {
+    let a_right = a.x.saturating_add(a.w as i32);
+    let a_bottom = a.y.saturating_add(a.h as i32);
+    let b_right = b.x.saturating_add(b.w as i32);
+    let b_bottom = b.y.saturating_add(b.h as i32);
+    a.x < b_right && a_right > b.x && a.y < b_bottom && a_bottom > b.y
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    fn tmp_dir() -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!("ns-windows-persist-{nanos}-{counter}"));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn sample_file() -> WindowsFile {
+        WindowsFile {
+            version: SCHEMA_VERSION,
+            windows: vec![
+                WindowEntry {
+                    vault: "personal".into(),
+                    x: 100,
+                    y: 80,
+                    w: 1200,
+                    h: 800,
+                },
+                WindowEntry {
+                    vault: "work".into(),
+                    x: 200,
+                    y: 120,
+                    w: 1100,
+                    h: 750,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn round_trip_serialises_and_deserialises() {
+        let dir = tmp_dir();
+        let path = windows_file_path(&dir);
+        let file = sample_file();
+
+        save(&path, &file).unwrap();
+        let loaded = load(&path).unwrap().expect("file should exist");
+
+        assert_eq!(loaded, file);
+    }
+
+    #[test]
+    fn load_returns_none_when_file_missing() {
+        let dir = tmp_dir();
+        let path = windows_file_path(&dir);
+        assert!(load(&path).unwrap().is_none());
+    }
+
+    #[test]
+    fn load_returns_none_when_file_empty() {
+        let dir = tmp_dir();
+        let path = windows_file_path(&dir);
+        fs::write(&path, b"").unwrap();
+        assert!(load(&path).unwrap().is_none());
+    }
+
+    #[test]
+    fn load_returns_none_when_file_corrupt() {
+        let dir = tmp_dir();
+        let path = windows_file_path(&dir);
+        fs::write(&path, b"{ this is not json").unwrap();
+        assert!(load(&path).unwrap().is_none());
+    }
+
+    #[test]
+    fn load_returns_none_for_unknown_schema_version() {
+        let dir = tmp_dir();
+        let path = windows_file_path(&dir);
+        fs::write(&path, br#"{"version":999,"windows":[]}"#).unwrap();
+        assert!(load(&path).unwrap().is_none());
+    }
+
+    #[test]
+    fn save_writes_through_tmp_file_then_renames() {
+        let dir = tmp_dir();
+        let path = windows_file_path(&dir);
+        save(&path, &sample_file()).unwrap();
+
+        // tmp file must be gone after a successful rename
+        let tmp = path.with_extension("json.tmp");
+        assert!(!tmp.exists(), "leftover tmp file: {tmp:?}");
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn save_creates_parent_directories() {
+        let dir = tmp_dir().join("nested").join("config");
+        let path = windows_file_path(&dir);
+        save(&path, &sample_file()).unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn save_overwrites_existing_file_atomically() {
+        let dir = tmp_dir();
+        let path = windows_file_path(&dir);
+        save(&path, &sample_file()).unwrap();
+
+        let mut updated = sample_file();
+        updated.windows[0].x = 999;
+        save(&path, &updated).unwrap();
+
+        let loaded = load(&path).unwrap().unwrap();
+        assert_eq!(loaded.windows[0].x, 999);
+    }
+
+    #[test]
+    fn dedupe_keeps_latest_entry_per_vault() {
+        let entries = vec![
+            WindowEntry {
+                vault: "a".into(),
+                x: 0,
+                y: 0,
+                w: 100,
+                h: 100,
+            },
+            WindowEntry {
+                vault: "b".into(),
+                x: 1,
+                y: 1,
+                w: 100,
+                h: 100,
+            },
+            WindowEntry {
+                vault: "a".into(),
+                x: 50,
+                y: 50,
+                w: 200,
+                h: 200,
+            },
+        ];
+
+        let result = dedupe_latest_per_vault(entries);
+
+        assert_eq!(result.len(), 2);
+        let a = result.iter().find(|e| e.vault == "a").unwrap();
+        assert_eq!(a.x, 50);
+        assert_eq!(a.w, 200);
+    }
+
+    #[test]
+    fn clamp_returns_rect_unchanged_when_it_overlaps_a_monitor() {
+        let monitor = Rect {
+            x: 0,
+            y: 0,
+            w: 1920,
+            h: 1080,
+        };
+        let rect = Rect {
+            x: 100,
+            y: 100,
+            w: 800,
+            h: 600,
+        };
+        assert_eq!(clamp_to_monitor(rect, &[monitor]), rect);
+    }
+
+    #[test]
+    fn clamp_recentres_when_rect_is_fully_off_screen() {
+        let monitor = Rect {
+            x: 0,
+            y: 0,
+            w: 1920,
+            h: 1080,
+        };
+        // Rect way off to the right
+        let rect = Rect {
+            x: 5000,
+            y: 5000,
+            w: 800,
+            h: 600,
+        };
+        let clamped = clamp_to_monitor(rect, &[monitor]);
+        assert_eq!(clamped.w, 800);
+        assert_eq!(clamped.h, 600);
+        // Should be centred: (1920-800)/2 = 560, (1080-600)/2 = 240
+        assert_eq!(clamped.x, 560);
+        assert_eq!(clamped.y, 240);
+    }
+
+    #[test]
+    fn clamp_keeps_rect_when_overlapping_secondary_monitor() {
+        let primary = Rect {
+            x: 0,
+            y: 0,
+            w: 1920,
+            h: 1080,
+        };
+        let secondary = Rect {
+            x: 1920,
+            y: 0,
+            w: 1920,
+            h: 1080,
+        };
+        let rect = Rect {
+            x: 2000,
+            y: 100,
+            w: 800,
+            h: 600,
+        };
+        assert_eq!(clamp_to_monitor(rect, &[primary, secondary]), rect);
+    }
+
+    #[test]
+    fn clamp_shrinks_rect_to_fit_when_recentring_a_huge_window() {
+        let monitor = Rect {
+            x: 0,
+            y: 0,
+            w: 1000,
+            h: 1000,
+        };
+        let rect = Rect {
+            x: 5000,
+            y: 5000,
+            w: 2000,
+            h: 2000,
+        };
+        let clamped = clamp_to_monitor(rect, &[monitor]);
+        assert_eq!(clamped.w, 1000);
+        assert_eq!(clamped.h, 1000);
+        assert_eq!(clamped.x, 0);
+        assert_eq!(clamped.y, 0);
+    }
+
+    #[test]
+    fn clamp_returns_rect_unchanged_when_no_monitors_known() {
+        let rect = Rect {
+            x: 10,
+            y: 10,
+            w: 100,
+            h: 100,
+        };
+        assert_eq!(clamp_to_monitor(rect, &[]), rect);
+    }
+}

--- a/crates/notesmith-tauri/tauri.conf.json
+++ b/crates/notesmith-tauri/tauri.conf.json
@@ -9,7 +9,7 @@
   },
   "app": {
     "macOSPrivateApi": true,
-    "withGlobalTauri": false,
+    "withGlobalTauri": true,
     "windows": [
       {
         "label": "main",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -54,6 +54,16 @@ cd crates/notesmith-tauri && cargo tauri build
 
 > Building with `cargo tauri ...` requires the Tauri CLI (`cargo install tauri-cli`) and platform tooling such as Xcode command line tools on macOS.
 
+### Desktop launch flags
+
+The desktop binary accepts a small set of flags before any Tauri-specific arguments:
+
+| Flag | Description |
+|------|-------------|
+| `--no-restore` | Skip the per-vault window restore on launch. Opens a single window on the default vault instead of replaying `windows.json`. The file is **not deleted** — only ignored for this launch. Useful when a saved window position has become problematic (e.g. a stale monitor layout). |
+
+`windows.json` lives in the platform app-config directory (`~/Library/Application Support/com.notesmith.desktop/windows.json` on macOS) and stores `{ vault, x, y, w, h }` for every currently-open vault window. It is rewritten atomically on window create, move, resize, real close, and app quit.
+
 ---
 
 ## mcp

--- a/ui/app/src/lib/app-shell-core.ts
+++ b/ui/app/src/lib/app-shell-core.ts
@@ -159,6 +159,7 @@ export function createAppShell(callbacks: AppShellCallbacks, dependencies: AppSh
 	let handleOpenQuickSwitcher: EventListener | null = null;
 	let availableVaults: string[] | null = null;
 	let lastResyncTime = 0;
+	let urlPinnedVault = false;
 
 	async function performResync(flushQueuedSaves = false) {
 		try {
@@ -241,6 +242,14 @@ export function createAppShell(callbacks: AppShellCallbacks, dependencies: AppSh
 			return;
 		}
 
+		// Sticky window: once a vault was URL-pinned for this window, never
+		// auto-swap it away — even if the vault disappears from the registry.
+		// The window stays bound to the original vault; the user can close it
+		// manually.
+		if (urlPinnedVault) {
+			return;
+		}
+
 		const nextVault =
 			registrations.find((vault) => vault.is_default)?.name ?? vaultNames[0] ?? '';
 		if (!nextVault) {
@@ -256,6 +265,7 @@ export function createAppShell(callbacks: AppShellCallbacks, dependencies: AppSh
 	async function init(vaultParam: string | null, vaults: string[]) {
 		teardown();
 		availableVaults = vaults;
+		urlPinnedVault = vaultParam !== null && vaultParam !== '';
 
 		handleOpenQuickSwitcher = () => callbacks.onOpenQuickSwitcher();
 		dependencies.targetWindow.addEventListener(
@@ -301,6 +311,7 @@ export function createAppShell(callbacks: AppShellCallbacks, dependencies: AppSh
 		removeVisibilityListener = () => {};
 		lastResyncTime = 0;
 		availableVaults = null;
+		urlPinnedVault = false;
 	}
 
 	return { init, teardown };

--- a/ui/app/src/lib/app-shell.svelte.ts
+++ b/ui/app/src/lib/app-shell.svelte.ts
@@ -5,11 +5,27 @@ import { connectSSE } from './sse';
 import { saveQueue } from './save-queue.ts';
 import { tabStore } from './tab-store.svelte';
 import { vaultStore } from './stores.svelte';
+import { attachWindowCloseConfirm } from './window-lifecycle.ts';
 
 export { classifyAppShellEvent, type AppShellEvent } from './app-shell-core.ts';
 export type { AppShellCallbacks } from './app-shell-core.ts';
 
 export function createAppShell(callbacks: AppShellCallbacks) {
+	// Register the Tauri close-confirm bridge once per window mount. The
+	// promise resolves to an unlisten fn; we don't currently expose a tear-
+	// down hook because the listener should live for the lifetime of the
+	// window. In tests the adapter resolves to null and this is a no-op.
+	void attachWindowCloseConfirm({
+		hasDirtyWork: () => tabStore.tabs.some((tab) => tab.dirty),
+		confirmDiscard: () =>
+			typeof window !== 'undefined' &&
+			typeof window.confirm === 'function'
+				? window.confirm(
+						'You have unsaved changes in this vault. Close the window and discard them?'
+					)
+				: true
+	});
+
 	return createCoreAppShell(callbacks, {
 		connectSSE,
 		listVaults,

--- a/ui/app/src/lib/components/CommandPalette.svelte
+++ b/ui/app/src/lib/components/CommandPalette.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 import { fuzzyFilter, type FuzzyMatch } from '$lib/fuzzy';
 import type { Command } from '$lib/commands';
+import { vaultStore } from '$lib/stores.svelte';
 
 let { commands, onClose }: { commands: Command[]; onClose: () => void } = $props();
+
 
 type CommandSection = {
 id: string;
@@ -24,9 +26,17 @@ let inputRef: HTMLInputElement | undefined;
 let resultsRef: HTMLDivElement | undefined;
 let recentIds = $state<string[]>(loadRecentIds());
 
+function recentCommandsKey(): string | null {
+const vault = vaultStore.currentVault;
+if (!vault) return null;
+return `notesmith:recent-commands:${vault}`;
+}
+
 function loadRecentIds(): string[] {
 try {
-const stored = localStorage.getItem('notesmith:recent-commands');
+const key = recentCommandsKey();
+if (!key) return [];
+const stored = localStorage.getItem(key);
 if (!stored) return [];
 const parsed = JSON.parse(stored);
 return Array.isArray(parsed) ? parsed.filter((value): value is string => typeof value === 'string') : [];
@@ -37,7 +47,9 @@ return [];
 
 function saveRecentIds(ids: string[]) {
 try {
-localStorage.setItem('notesmith:recent-commands', JSON.stringify(ids));
+const key = recentCommandsKey();
+if (!key) return;
+localStorage.setItem(key, JSON.stringify(ids));
 } catch {
 // Ignore storage failures.
 }

--- a/ui/app/src/lib/components/OnboardingCard.svelte
+++ b/ui/app/src/lib/components/OnboardingCard.svelte
@@ -1,15 +1,23 @@
 <script lang="ts">
 import { onMount } from 'svelte';
 import { fade } from 'svelte/transition';
+import { vaultStore } from '$lib/stores.svelte';
 
-const STORAGE_KEY = 'notesmith:onboarding-dismissed';
+const STORAGE_PREFIX = 'notesmith:onboarding-dismissed';
+
+function storageKey(): string | null {
+const vault = vaultStore.currentVault;
+if (!vault) return null;
+return `${STORAGE_PREFIX}:${vault}`;
+}
 
 let ready = $state(false);
 let dismissed = $state(false);
 
 onMount(() => {
 try {
-dismissed = localStorage.getItem(STORAGE_KEY) === 'true';
+const key = storageKey();
+dismissed = key ? localStorage.getItem(key) === 'true' : false;
 } catch {
 dismissed = false;
 }
@@ -20,7 +28,9 @@ ready = true;
 function dismiss() {
 dismissed = true;
 try {
-localStorage.setItem(STORAGE_KEY, 'true');
+const key = storageKey();
+if (!key) return;
+localStorage.setItem(key, 'true');
 } catch {
 // ignore storage failures
 }

--- a/ui/app/src/lib/components/OpenFolderAsVaultModal.svelte
+++ b/ui/app/src/lib/components/OpenFolderAsVaultModal.svelte
@@ -1,0 +1,264 @@
+<script lang="ts">
+	import { onMount, tick } from 'svelte';
+	import { listVaults } from '$lib/api';
+	import {
+		defaultNameFromPath,
+		resolveTauri,
+		validateVaultName,
+		type TauriBridge
+	} from '$lib/open-folder-as-vault';
+
+	let {
+		onClose,
+		bridge = resolveTauri()
+	}: {
+		onClose: () => void;
+		bridge?: TauriBridge | null;
+	} = $props();
+
+	let phase = $state<'picking' | 'naming' | 'submitting'>('picking');
+	let path = $state('');
+	let name = $state('');
+	let existing = $state<string[]>([]);
+	let error = $state<string | null>(null);
+	let nameInput = $state<HTMLInputElement | undefined>(undefined);
+
+	onMount(() => {
+		void start();
+	});
+
+	async function start() {
+		if (!bridge) {
+			error = 'The folder picker is only available inside the Notesmith desktop app.';
+			phase = 'naming';
+			return;
+		}
+		try {
+			existing = (await listVaults()).map((v) => v.name);
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load existing vaults';
+		}
+		try {
+			const picked = (await bridge.invoke('pick_vault_folder')) as string | null;
+			if (!picked) {
+				onClose();
+				return;
+			}
+			path = picked;
+			name = defaultNameFromPath(picked);
+			phase = 'naming';
+			await tick();
+			nameInput?.focus();
+			nameInput?.select();
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Folder picker failed';
+			phase = 'naming';
+		}
+	}
+
+	async function confirm() {
+		const result = validateVaultName(name, existing);
+		if (!result.ok) {
+			error = result.error.message;
+			return;
+		}
+		if (!bridge) {
+			error = 'Cannot register vaults outside the Notesmith desktop app.';
+			return;
+		}
+		if (!path) {
+			error = 'No folder selected.';
+			return;
+		}
+		phase = 'submitting';
+		error = null;
+		try {
+			await bridge.invoke('open_folder_as_vault', {
+				path,
+				displayName: result.value
+			});
+			onClose();
+		} catch (e) {
+			error = typeof e === 'string' ? e : e instanceof Error ? e.message : 'Failed to register vault';
+			phase = 'naming';
+			await tick();
+			nameInput?.focus();
+		}
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape') {
+			event.preventDefault();
+			onClose();
+		} else if (event.key === 'Enter' && phase === 'naming') {
+			event.preventDefault();
+			void confirm();
+		}
+	}
+</script>
+
+<div
+	class="modal-backdrop"
+	role="dialog"
+	aria-modal="true"
+	aria-labelledby="open-folder-title"
+	tabindex="-1"
+	onclick={(event) => event.target === event.currentTarget && onClose()}
+	onkeydown={handleKeydown}
+>
+	<div class="modal-sheet">
+		<h2 id="open-folder-title" class="modal-title">Open Folder as Vault</h2>
+
+		{#if phase === 'picking'}
+			<p class="modal-body">Choose a folder to register as a new vault…</p>
+		{:else}
+			<p class="modal-body">
+				Folder: <code class="folder-path" title={path}>{path || '(none)'}</code>
+			</p>
+			<label class="field">
+				<span class="field-label">Vault name</span>
+				<input
+					bind:this={nameInput}
+					bind:value={name}
+					type="text"
+					class="name-input"
+					placeholder="e.g. Personal"
+					disabled={phase === 'submitting'}
+					aria-invalid={error !== null}
+					aria-describedby={error ? 'open-folder-error' : undefined}
+				/>
+			</label>
+			{#if error}
+				<div id="open-folder-error" class="inline-error" role="alert">{error}</div>
+			{/if}
+			<div class="modal-actions">
+				<button type="button" class="btn-secondary" onclick={onClose}>Cancel</button>
+				<button
+					type="button"
+					class="btn-primary"
+					disabled={phase === 'submitting' || !path}
+					onclick={() => void confirm()}
+				>
+					{phase === 'submitting' ? 'Opening…' : 'Open Vault'}
+				</button>
+			</div>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.modal-backdrop {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.5);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 200;
+	}
+
+	.modal-sheet {
+		background: var(--ns-surface-elevated);
+		color: var(--ns-text);
+		border: 1px solid var(--ns-border);
+		border-radius: 8px;
+		padding: 20px;
+		min-width: 420px;
+		max-width: 90vw;
+		box-shadow: 0 10px 40px rgba(0, 0, 0, 0.4);
+	}
+
+	.modal-title {
+		margin: 0 0 12px;
+		font-size: 16px;
+		font-weight: 600;
+	}
+
+	.modal-body {
+		margin: 0 0 12px;
+		font-size: 13px;
+		color: var(--ns-text-secondary);
+	}
+
+	.folder-path {
+		font-family: var(--ns-font-mono, monospace);
+		background: var(--ns-bg);
+		padding: 2px 6px;
+		border-radius: 3px;
+		font-size: 12px;
+		word-break: break-all;
+	}
+
+	.field {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		margin-bottom: 8px;
+	}
+
+	.field-label {
+		font-size: 11px;
+		color: var(--ns-text-muted);
+	}
+
+	.name-input {
+		padding: 6px 10px;
+		border: 1px solid var(--ns-border-input);
+		border-radius: 4px;
+		background: var(--ns-input-bg);
+		color: var(--ns-text);
+		font-size: 13px;
+	}
+
+	.name-input:focus {
+		outline: none;
+		border-color: var(--ns-accent);
+	}
+
+	.inline-error {
+		color: var(--ns-danger);
+		font-size: 12px;
+		margin-bottom: 8px;
+	}
+
+	.modal-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 8px;
+		margin-top: 12px;
+	}
+
+	.btn-primary,
+	.btn-secondary {
+		padding: 6px 14px;
+		border-radius: 4px;
+		font-size: 13px;
+		cursor: pointer;
+		border: 1px solid var(--ns-border-strong);
+	}
+
+	.btn-primary {
+		background: var(--ns-accent-bg);
+		color: var(--ns-text-inverse);
+		border-color: var(--ns-accent-bg);
+	}
+
+	.btn-primary:hover:not(:disabled) {
+		background: var(--ns-accent-bg-hover);
+	}
+
+	.btn-primary:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.btn-secondary {
+		background: transparent;
+		color: var(--ns-text-muted);
+	}
+
+	.btn-secondary:hover {
+		background: var(--ns-surface-hover);
+		color: var(--ns-text);
+	}
+</style>

--- a/ui/app/src/lib/components/RightRail.svelte
+++ b/ui/app/src/lib/components/RightRail.svelte
@@ -118,9 +118,17 @@
 		tabStore.selectNote(path);
 	}
 
+	function railTabKey(): string | null {
+		const vault = vaultStore.currentVault;
+		if (!vault) return null;
+		return `notesmith:rail-tab:${vault}`;
+	}
+
 	function loadTab(): RailTab {
 		try {
-			const saved = localStorage.getItem('notesmith:rail-tab');
+			const key = railTabKey();
+			if (!key) return 'metadata';
+			const saved = localStorage.getItem(key);
 			if (saved === 'metadata' || saved === 'links' || saved === 'toc') {
 				return saved;
 			}
@@ -132,7 +140,9 @@
 	function setTab(tab: RailTab) {
 		activeTab = tab;
 		try {
-			localStorage.setItem('notesmith:rail-tab', tab);
+			const key = railTabKey();
+			if (!key) return;
+			localStorage.setItem(key, tab);
 		} catch {}
 	}
 

--- a/ui/app/src/lib/components/VaultSwitcher.svelte
+++ b/ui/app/src/lib/components/VaultSwitcher.svelte
@@ -1,38 +1,135 @@
 <script lang="ts">
-	import { tabStore } from '$lib/tab-store.svelte';
 	import { vaultStore } from '$lib/stores.svelte';
 
 	let { vaults }: { vaults: string[] } = $props();
 
-	function switchVault(event: Event) {
-		const target = event.target as HTMLSelectElement;
-		vaultStore.currentVault = target.value;
-		tabStore.selectedPath = null;
-		void vaultStore.loadNotes();
+	const OPEN_FOLDER_EVENT = 'notesmith://open-folder-as-vault';
+
+	function resolveTauri():
+		| { invoke: (cmd: string, args: Record<string, unknown>) => Promise<unknown> }
+		| null {
+		if (typeof window === 'undefined') return null;
+		const t = (window as unknown as {
+			__TAURI__?: { core?: { invoke?: (cmd: string, args: Record<string, unknown>) => Promise<unknown> } };
+		}).__TAURI__;
+		if (!t?.core?.invoke) return null;
+		return { invoke: t.core.invoke };
+	}
+
+	async function openVault(vault: string) {
+		if (vault === vaultStore.currentVault) return;
+		const tauri = resolveTauri();
+		if (!tauri) {
+			// Dev / browser mode — navigate by setting ?vault=.
+			if (typeof window !== 'undefined') {
+				const url = new URL(window.location.href);
+				url.searchParams.set('vault', vault);
+				window.location.href = url.toString();
+			}
+			return;
+		}
+		try {
+			await tauri.invoke('open_vault_window', { vault });
+		} catch (error) {
+			console.warn('open_vault_window failed', error);
+		}
+	}
+
+	function openFolderAsVault() {
+		if (typeof window === 'undefined') return;
+		// #103 will land a modal that listens for this event. For now the
+		// menu route also emits the same event from the Tauri side.
+		window.dispatchEvent(new CustomEvent(OPEN_FOLDER_EVENT));
 	}
 </script>
 
-<div class="vault-switcher">
-	<select onchange={switchVault} value={vaultStore.currentVault}>
+<div class="vault-switcher" role="group" aria-label="Vaults">
+	<ul class="vault-list">
 		{#each vaults as vault (vault)}
-			<option value={vault}>{vault}</option>
+			{@const isCurrent = vault === vaultStore.currentVault}
+			<li>
+				<button
+					type="button"
+					class="vault-row"
+					class:current={isCurrent}
+					disabled={isCurrent}
+					aria-current={isCurrent ? 'true' : undefined}
+					onclick={() => void openVault(vault)}
+					title={isCurrent ? `${vault} (this window)` : `Open ${vault} in a new window`}
+				>
+					<span class="vault-name">{vault}</span>
+					{#if isCurrent}
+						<span class="vault-tag">(this window)</span>
+					{/if}
+				</button>
+			</li>
 		{/each}
-	</select>
+		<li>
+			<button
+				type="button"
+				class="vault-row open-folder"
+				onclick={openFolderAsVault}
+				title="Open another folder as a vault"
+			>
+				<span class="vault-name">Open Folder…</span>
+			</button>
+		</li>
+	</ul>
 </div>
 
 <style>
 	.vault-switcher {
-		padding: 8px 12px;
+		padding: 6px 4px;
 		border-bottom: 1px solid var(--ns-border);
 	}
 
-	select {
+	.vault-list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.vault-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 8px;
 		width: 100%;
-		padding: 6px 8px;
-		background: var(--ns-input-bg);
+		padding: 6px 10px;
+		background: transparent;
 		color: var(--ns-text);
-		border: 1px solid var(--ns-border-input);
+		border: 1px solid transparent;
 		border-radius: 4px;
 		font-size: 13px;
+		text-align: left;
+		cursor: pointer;
+	}
+
+	.vault-row:hover:not(:disabled) {
+		background: var(--ns-surface-hover);
+	}
+
+	.vault-row.current {
+		background: var(--ns-surface-active);
+		cursor: default;
+	}
+
+	.vault-row:disabled {
+		opacity: 1;
+	}
+
+	.vault-tag {
+		font-size: 11px;
+		opacity: 0.7;
+	}
+
+	.vault-row.open-folder {
+		border-top: 1px dashed var(--ns-border);
+		margin-top: 4px;
+		padding-top: 8px;
+		opacity: 0.85;
 	}
 </style>

--- a/ui/app/src/lib/components/VaultsSettings.svelte
+++ b/ui/app/src/lib/components/VaultsSettings.svelte
@@ -11,6 +11,8 @@
 		type Capabilities
 	} from '$lib/api';
 	import { toastStore } from '$lib/toast-store.svelte';
+	import { onMount, onDestroy } from 'svelte';
+	import { resolveTauri } from '$lib/open-folder-as-vault';
 
 	interface Props {
 		capabilities: Capabilities | null;
@@ -36,6 +38,40 @@
 
 	// Reindex state
 	let reindexingVault = $state<string | null>(null);
+
+	// Open-vault tracking (#103) — disable Remove for vaults with a live window.
+	let openVaults = $state<string[]>([]);
+	const tauriBridge = resolveTauri();
+	let openVaultsPollHandle: ReturnType<typeof setInterval> | null = null;
+
+	async function refreshOpenVaults() {
+		if (!tauriBridge) {
+			openVaults = [];
+			return;
+		}
+		try {
+			const result = (await tauriBridge.invoke('list_open_vaults')) as string[];
+			openVaults = Array.isArray(result) ? result : [];
+		} catch {
+			openVaults = [];
+		}
+	}
+
+	onMount(() => {
+		void refreshOpenVaults();
+		if (tauriBridge) {
+			// Light polling so the Remove buttons re-enable when the user closes a
+			// vault window without leaving Settings.
+			openVaultsPollHandle = setInterval(() => void refreshOpenVaults(), 2000);
+		}
+	});
+
+	onDestroy(() => {
+		if (openVaultsPollHandle) {
+			clearInterval(openVaultsPollHandle);
+			openVaultsPollHandle = null;
+		}
+	});
 
 	// ── Load ─────────────────────────────────────────────────────
 	async function load() {
@@ -128,6 +164,10 @@
 	// ── Remove ───────────────────────────────────────────────────
 	async function handleRemove(name: string) {
 		error = null;
+		if (openVaults.includes(name)) {
+			error = `Close the "${name}" window first before removing this vault.`;
+			return;
+		}
 		if (!window.confirm(`Remove vault "${name}"? This only unregisters the vault — your files will not be deleted.`)) {
 			return;
 		}
@@ -222,8 +262,12 @@
 						<button
 							type="button"
 							class="btn-small danger"
-							disabled={vault.is_default}
-							title={vault.is_default ? 'Cannot remove the default vault' : 'Remove vault'}
+							disabled={vault.is_default || openVaults.includes(vault.name)}
+							title={vault.is_default
+								? 'Cannot remove the default vault'
+								: openVaults.includes(vault.name)
+									? `Close the "${vault.name}" window first`
+									: 'Remove vault'}
 							onclick={() => void handleRemove(vault.name)}
 						>Remove</button>
 					</div>

--- a/ui/app/src/lib/open-folder-as-vault.test.ts
+++ b/ui/app/src/lib/open-folder-as-vault.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { validateVaultName, defaultNameFromPath } from './open-folder-as-vault';
+
+describe('validateVaultName', () => {
+  it('accepts a clean unique name', () => {
+    expect(validateVaultName('Personal', ['Work'])).toEqual({
+      ok: true,
+      value: 'Personal'
+    });
+  });
+
+  it('trims whitespace', () => {
+    expect(validateVaultName('  Notes  ', [])).toEqual({
+      ok: true,
+      value: 'Notes'
+    });
+  });
+
+  it('rejects empty / whitespace-only', () => {
+    const r = validateVaultName('   ', []);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.message).toMatch(/empty/i);
+  });
+
+  it('rejects names starting with a dot', () => {
+    const r = validateVaultName('.hidden', []);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.message).toMatch(/dot/i);
+  });
+
+  it('rejects path separators', () => {
+    expect(validateVaultName('a/b', []).ok).toBe(false);
+    expect(validateVaultName('a\\b', []).ok).toBe(false);
+  });
+
+  it('rejects duplicates (case-sensitive, matching backend)', () => {
+    const r = validateVaultName('Work', ['Work', 'Home']);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.message).toMatch(/already exists/i);
+  });
+
+  it('allows distinct case (case-sensitive)', () => {
+    expect(validateVaultName('work', ['Work']).ok).toBe(true);
+  });
+});
+
+describe('defaultNameFromPath', () => {
+  it('uses the last path segment', () => {
+    expect(defaultNameFromPath('/Users/x/Notes')).toBe('Notes');
+    expect(defaultNameFromPath('C:\\Users\\x\\Notes')).toBe('Notes');
+  });
+
+  it('strips trailing slashes', () => {
+    expect(defaultNameFromPath('/Users/x/Notes/')).toBe('Notes');
+    expect(defaultNameFromPath('/Users/x/Notes///')).toBe('Notes');
+  });
+
+  it('strips leading dots from hidden folders', () => {
+    expect(defaultNameFromPath('/Users/x/.vault')).toBe('vault');
+  });
+
+  it('returns empty when path is just separators', () => {
+    expect(defaultNameFromPath('///')).toBe('');
+  });
+});

--- a/ui/app/src/lib/open-folder-as-vault.ts
+++ b/ui/app/src/lib/open-folder-as-vault.ts
@@ -1,0 +1,71 @@
+/**
+ * Pure validation + Tauri-bridge helpers for the "Open Folder as Vault" flow.
+ *
+ * Keeping these out of the Svelte component lets them be unit-tested with
+ * Vitest without spinning up a renderer.
+ */
+
+export interface VaultNameError {
+  message: string;
+}
+
+/**
+ * Validate a candidate display name against the existing vault registry.
+ * Returns the trimmed name on success, or a structured error.
+ *
+ * Mirrors `validate_vault_display_name` in `crates/notesmith-tauri/src/vault_menu.rs`
+ * so the user gets immediate feedback before the round-trip.
+ */
+export function validateVaultName(
+  candidate: string,
+  existing: readonly string[]
+): { ok: true; value: string } | { ok: false; error: VaultNameError } {
+  const trimmed = candidate.trim();
+  if (!trimmed) {
+    return { ok: false, error: { message: 'Vault name cannot be empty.' } };
+  }
+  if (trimmed.startsWith('.')) {
+    return {
+      ok: false,
+      error: { message: 'Vault name cannot start with a dot.' }
+    };
+  }
+  if (trimmed.includes('/') || trimmed.includes('\\')) {
+    return {
+      ok: false,
+      error: { message: 'Vault name cannot contain path separators.' }
+    };
+  }
+  if (existing.some((name) => name === trimmed)) {
+    return {
+      ok: false,
+      error: { message: `A vault named "${trimmed}" already exists.` }
+    };
+  }
+  return { ok: true, value: trimmed };
+}
+
+/**
+ * Derive a default display name from a folder path. Picks the last non-empty
+ * segment and trims any leading dots so the result passes `validateVaultName`.
+ */
+export function defaultNameFromPath(path: string): string {
+  const cleaned = path.replace(/[\\/]+$/, '');
+  const parts = cleaned.split(/[\\/]/);
+  const last = parts[parts.length - 1] ?? '';
+  return last.replace(/^\.+/, '').trim();
+}
+
+export interface TauriBridge {
+  invoke: (cmd: string, args?: Record<string, unknown>) => Promise<unknown>;
+}
+
+export function resolveTauri(): TauriBridge | null {
+  if (typeof window === 'undefined') return null;
+  const t = (window as unknown as {
+    __TAURI__?: { core?: { invoke?: (cmd: string, args: Record<string, unknown>) => Promise<unknown> } };
+  }).__TAURI__;
+  if (!t?.core?.invoke) return null;
+  const inv = t.core.invoke;
+  return { invoke: (cmd, args) => inv(cmd, args ?? {}) };
+}

--- a/ui/app/src/lib/tab-storage-key.ts
+++ b/ui/app/src/lib/tab-storage-key.ts
@@ -1,0 +1,11 @@
+const STORAGE_KEY_PREFIX = 'notesmith:tabs';
+
+/**
+ * Per-vault storage key for the tab state. Returns null when no vault is
+ * selected so callers can skip the read/write (avoids cross-window clobber
+ * of a stale, unscoped `notesmith:tabs` blob).
+ */
+export function tabStorageKey(vault: string): string | null {
+  if (!vault) return null;
+  return `${STORAGE_KEY_PREFIX}:${vault}`;
+}

--- a/ui/app/src/lib/tab-store.svelte.ts
+++ b/ui/app/src/lib/tab-store.svelte.ts
@@ -16,8 +16,11 @@ type TabState,
 type ViewMode
 } from './tab-state';
 import { vaultStore } from './stores.svelte';
+import { tabStorageKey } from './tab-storage-key';
 
-const STORAGE_KEY = 'notesmith:tabs';
+function storageKey(): string | null {
+	return tabStorageKey(vaultStore.currentVault);
+}
 
 export type { Tab, ViewMode } from './tab-state';
 
@@ -104,7 +107,9 @@ this._persistTabs();
 
 restoreTabs() {
 try {
-const restored = restoreTabState(localStorage.getItem(STORAGE_KEY));
+const key = storageKey();
+if (!key) return;
+const restored = restoreTabState(localStorage.getItem(key));
 if (!restored) {
 return;
 }
@@ -136,8 +141,10 @@ this._recentlyClosed = state.recentlyClosed;
 
 private _persistTabs() {
 try {
+const key = storageKey();
+if (!key) return;
 localStorage.setItem(
-STORAGE_KEY,
+key,
 serializeTabState({
 tabs: this.tabs,
 activeTabIndex: this.activeTabIndex

--- a/ui/app/src/lib/tab-store.test.ts
+++ b/ui/app/src/lib/tab-store.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { tabStorageKey } from './tab-storage-key';
+
+describe('tabStorageKey', () => {
+  it('returns null when vault is empty (avoids cross-window clobber)', () => {
+    expect(tabStorageKey('')).toBeNull();
+  });
+
+  it('namespaces by vault name', () => {
+    expect(tabStorageKey('work')).toBe('notesmith:tabs:work');
+    expect(tabStorageKey('home')).toBe('notesmith:tabs:home');
+  });
+
+  it('produces distinct keys for different vaults so they never collide', () => {
+    expect(tabStorageKey('work')).not.toBe(tabStorageKey('home'));
+  });
+});

--- a/ui/app/src/lib/window-lifecycle.test.ts
+++ b/ui/app/src/lib/window-lifecycle.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from 'vitest';
+import { attachWindowCloseConfirm, type TauriAdapter } from './window-lifecycle';
+
+function makeTauri(): {
+  adapter: TauriAdapter;
+  fire: (payload?: unknown) => Promise<void>;
+  invoke: ReturnType<typeof vi.fn>;
+  unlisten: ReturnType<typeof vi.fn>;
+} {
+  let handler: ((payload: unknown) => void) | null = null;
+  const unlisten = vi.fn();
+  const invoke = vi.fn(async () => undefined);
+  const adapter: TauriAdapter = {
+    listen: async (_event, h) => {
+      handler = h;
+      return unlisten;
+    },
+    invoke
+  };
+  return {
+    adapter,
+    invoke,
+    unlisten,
+    fire: async (payload) => {
+      handler?.(payload);
+      await Promise.resolve();
+      await Promise.resolve();
+    }
+  };
+}
+
+describe('attachWindowCloseConfirm', () => {
+  it('invokes confirm_window_close with allow:true when no tabs are dirty', async () => {
+    const { adapter, fire, invoke } = makeTauri();
+    await attachWindowCloseConfirm({
+      hasDirtyWork: () => false,
+      confirmDiscard: () => false,
+      tauri: adapter
+    });
+
+    await fire();
+
+    expect(invoke).toHaveBeenCalledWith('confirm_window_close', { allow: true });
+  });
+
+  it('asks the user when tabs are dirty and forwards the answer', async () => {
+    const { adapter, fire, invoke } = makeTauri();
+    const confirmDiscard = vi.fn(async () => false);
+
+    await attachWindowCloseConfirm({
+      hasDirtyWork: () => true,
+      confirmDiscard,
+      tauri: adapter
+    });
+
+    await fire();
+
+    expect(confirmDiscard).toHaveBeenCalled();
+    expect(invoke).toHaveBeenCalledWith('confirm_window_close', { allow: false });
+  });
+
+  it('invokes with allow:true when user discards dirty work', async () => {
+    const { adapter, fire, invoke } = makeTauri();
+    await attachWindowCloseConfirm({
+      hasDirtyWork: () => true,
+      confirmDiscard: () => true,
+      tauri: adapter
+    });
+
+    await fire();
+
+    expect(invoke).toHaveBeenCalledWith('confirm_window_close', { allow: true });
+  });
+
+  it('returns an unlisten teardown function', async () => {
+    const { adapter, unlisten } = makeTauri();
+    const teardown = await attachWindowCloseConfirm({
+      hasDirtyWork: () => false,
+      confirmDiscard: () => true,
+      tauri: adapter
+    });
+
+    teardown();
+
+    expect(unlisten).toHaveBeenCalled();
+  });
+
+  it('is a no-op outside of Tauri (no adapter available)', async () => {
+    const teardown = await attachWindowCloseConfirm({
+      hasDirtyWork: () => true,
+      confirmDiscard: () => false,
+      tauri: null
+    });
+
+    // Should not throw, and should return a callable teardown.
+    expect(typeof teardown).toBe('function');
+    teardown();
+  });
+
+  it('swallows invoke errors without throwing into the event loop', async () => {
+    const { adapter, fire, invoke } = makeTauri();
+    invoke.mockRejectedValueOnce(new Error('boom'));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await attachWindowCloseConfirm({
+      hasDirtyWork: () => false,
+      confirmDiscard: () => true,
+      tauri: adapter
+    });
+
+    await fire();
+
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});

--- a/ui/app/src/lib/window-lifecycle.test.ts
+++ b/ui/app/src/lib/window-lifecycle.test.ts
@@ -113,11 +113,40 @@ describe('attachWindowCloseConfirm', () => {
     expect(warnSpy).toHaveBeenCalled();
     warnSpy.mockRestore();
   });
+
+  it('ignores close requests for a different Tauri window label', async () => {
+    const { adapter, fire, invoke } = makeTauri();
+    adapter.currentLabel = 'main:alpha-123';
+
+    await attachWindowCloseConfirm({
+      hasDirtyWork: () => false,
+      confirmDiscard: () => true,
+      tauri: adapter
+    });
+
+    await fire('main:beta-456');
+
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it('handles close requests matching the current Tauri window label', async () => {
+    const { adapter, fire, invoke } = makeTauri();
+    adapter.currentLabel = 'main:alpha-123';
+
+    await attachWindowCloseConfirm({
+      hasDirtyWork: () => false,
+      confirmDiscard: () => true,
+      tauri: adapter
+    });
+
+    await fire('main:alpha-123');
+
+    expect(invoke).toHaveBeenCalledWith('confirm_window_close', { allow: true });
+  });
 });
 
 describe('resolveTauri', () => {
-  it('uses the current WebviewWindow listener instead of the global event listener', async () => {
-    const scopedListen = vi.fn(async () => vi.fn());
+  it('uses the global listener and exposes the current WebviewWindow label', async () => {
     const globalListen = vi.fn(async () => vi.fn());
     const invoke = vi.fn(async () => undefined);
     vi.stubGlobal('window', {
@@ -126,7 +155,7 @@ describe('resolveTauri', () => {
         event: { listen: globalListen },
         webviewWindow: {
           getCurrentWebviewWindow: () => ({
-            listen: scopedListen
+            label: 'main:alpha-123'
           })
         }
       }
@@ -135,11 +164,11 @@ describe('resolveTauri', () => {
     const adapter = resolveTauri();
     await adapter?.listen('notesmith://close-requested', () => {});
 
-    expect(scopedListen).toHaveBeenCalledWith(
+    expect(adapter?.currentLabel).toBe('main:alpha-123');
+    expect(globalListen).toHaveBeenCalledWith(
       'notesmith://close-requested',
       expect.any(Function)
     );
-    expect(globalListen).not.toHaveBeenCalled();
 
     vi.unstubAllGlobals();
   });

--- a/ui/app/src/lib/window-lifecycle.test.ts
+++ b/ui/app/src/lib/window-lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { attachWindowCloseConfirm, type TauriAdapter } from './window-lifecycle';
+import { attachWindowCloseConfirm, resolveTauri, type TauriAdapter } from './window-lifecycle';
 
 function makeTauri(): {
   adapter: TauriAdapter;
@@ -112,5 +112,35 @@ describe('attachWindowCloseConfirm', () => {
 
     expect(warnSpy).toHaveBeenCalled();
     warnSpy.mockRestore();
+  });
+});
+
+describe('resolveTauri', () => {
+  it('uses the current WebviewWindow listener instead of the global event listener', async () => {
+    const scopedListen = vi.fn(async () => vi.fn());
+    const globalListen = vi.fn(async () => vi.fn());
+    const invoke = vi.fn(async () => undefined);
+    vi.stubGlobal('window', {
+      __TAURI__: {
+        core: { invoke },
+        event: { listen: globalListen },
+        webviewWindow: {
+          getCurrentWebviewWindow: () => ({
+            listen: scopedListen
+          })
+        }
+      }
+    });
+
+    const adapter = resolveTauri();
+    await adapter?.listen('notesmith://close-requested', () => {});
+
+    expect(scopedListen).toHaveBeenCalledWith(
+      'notesmith://close-requested',
+      expect.any(Function)
+    );
+    expect(globalListen).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
   });
 });

--- a/ui/app/src/lib/window-lifecycle.ts
+++ b/ui/app/src/lib/window-lifecycle.ts
@@ -23,6 +23,7 @@ export interface CloseConfirmDeps {
 }
 
 export interface TauriAdapter {
+  currentLabel?: string;
   listen: (event: string, handler: (payload: unknown) => void) => Promise<() => void>;
   invoke: (cmd: string, args?: Record<string, unknown>) => Promise<unknown>;
 }
@@ -38,7 +39,10 @@ export async function attachWindowCloseConfirm(
     return () => {};
   }
 
-  const unlisten = await tauri.listen(CLOSE_REQUESTED_EVENT, async () => {
+  const unlisten = await tauri.listen(CLOSE_REQUESTED_EVENT, async (payload) => {
+    if (typeof payload === 'string' && tauri.currentLabel && payload !== tauri.currentLabel) {
+      return;
+    }
     const allow = deps.hasDirtyWork() ? await deps.confirmDiscard() : true;
     try {
       await tauri.invoke('confirm_window_close', { allow });
@@ -59,22 +63,19 @@ export function resolveTauri(): TauriAdapter | null {
     return null;
   }
   const invoke = t.core.invoke;
-  const currentTarget =
-    t.webviewWindow?.getCurrentWebviewWindow?.() ?? t.window?.getCurrentWindow?.();
-
-  if (currentTarget?.listen) {
-    return {
-      listen: (event, handler) =>
-        currentTarget.listen(event, (envelope: { payload: unknown }) => handler(envelope.payload)),
-      invoke: (cmd, args) => invoke(cmd, args ?? {})
-    };
-  }
 
   if (!t.event?.listen) {
     return null;
   }
 
+  const currentLabel =
+    t.webviewWindow?.getCurrentWebviewWindow?.().label ??
+    t.window?.getCurrentWindow?.().label ??
+    (window as unknown as { __TAURI_INTERNALS__?: TauriInternals }).__TAURI_INTERNALS__?.metadata
+      ?.currentWindow?.label;
+
   return {
+    currentLabel,
     listen: (event, handler) =>
       t.event!.listen(event, (envelope: { payload: unknown }) => handler(envelope.payload)),
     invoke: (cmd, args) => invoke(cmd, args ?? {})
@@ -92,16 +93,21 @@ interface TauriRuntime {
     invoke: (cmd: string, args: Record<string, unknown>) => Promise<unknown>;
   };
   window?: {
-    getCurrentWindow?: () => ScopedTauriEventTarget;
+    getCurrentWindow?: () => TauriCurrentTarget;
   };
   webviewWindow?: {
-    getCurrentWebviewWindow?: () => ScopedTauriEventTarget;
+    getCurrentWebviewWindow?: () => TauriCurrentTarget;
   };
 }
 
-interface ScopedTauriEventTarget {
-  listen: (
-    event: string,
-    handler: (envelope: { payload: unknown }) => void
-  ) => Promise<() => void>;
+interface TauriCurrentTarget {
+  label?: string;
+}
+
+interface TauriInternals {
+  metadata?: {
+    currentWindow?: {
+      label?: string;
+    };
+  };
 }

--- a/ui/app/src/lib/window-lifecycle.ts
+++ b/ui/app/src/lib/window-lifecycle.ts
@@ -1,0 +1,78 @@
+/**
+ * Window-lifecycle bridge between the Tauri shell and the SvelteKit webview.
+ *
+ * The Tauri close handler (see `crates/notesmith-tauri/src/main.rs`) prevents
+ * the OS close when the red button is clicked and emits a
+ * `notesmith://close-requested` event. The frontend decides whether any
+ * tabs are dirty, asks the user to confirm if so, and reports the answer
+ * back via the `confirm_window_close` command.
+ *
+ * When the page is not running inside Tauri (e.g. dev mode in a browser),
+ * `attachWindowCloseConfirm` becomes a no-op so the webview still works.
+ */
+
+const CLOSE_REQUESTED_EVENT = 'notesmith://close-requested';
+
+export interface CloseConfirmDeps {
+  /** Should return true when the user has any unsaved work. */
+  hasDirtyWork: () => boolean;
+  /** Show a confirmation dialog; resolves to true when the user wants to discard and close. */
+  confirmDiscard: () => Promise<boolean> | boolean;
+  /** Override for tests. Returns true if `__TAURI__` is available. */
+  tauri?: TauriAdapter | null;
+}
+
+export interface TauriAdapter {
+  listen: (event: string, handler: (payload: unknown) => void) => Promise<() => void>;
+  invoke: (cmd: string, args?: Record<string, unknown>) => Promise<unknown>;
+}
+
+/**
+ * Wire the `notesmith://close-requested` listener and return a teardown fn.
+ */
+export async function attachWindowCloseConfirm(
+  deps: CloseConfirmDeps
+): Promise<() => void> {
+  const tauri = deps.tauri ?? resolveTauri();
+  if (!tauri) {
+    return () => {};
+  }
+
+  const unlisten = await tauri.listen(CLOSE_REQUESTED_EVENT, async () => {
+    const allow = deps.hasDirtyWork() ? await deps.confirmDiscard() : true;
+    try {
+      await tauri.invoke('confirm_window_close', { allow });
+    } catch (error) {
+      console.warn('confirm_window_close failed', error);
+    }
+  });
+
+  return unlisten;
+}
+
+function resolveTauri(): TauriAdapter | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  const t = (window as unknown as { __TAURI__?: TauriRuntime }).__TAURI__;
+  if (!t?.event?.listen || !t.core?.invoke) {
+    return null;
+  }
+  return {
+    listen: (event, handler) =>
+      t.event!.listen(event, (envelope: { payload: unknown }) => handler(envelope.payload)),
+    invoke: (cmd, args) => t.core!.invoke(cmd, args ?? {})
+  };
+}
+
+interface TauriRuntime {
+  event?: {
+    listen: (
+      event: string,
+      handler: (envelope: { payload: unknown }) => void
+    ) => Promise<() => void>;
+  };
+  core?: {
+    invoke: (cmd: string, args: Record<string, unknown>) => Promise<unknown>;
+  };
+}

--- a/ui/app/src/lib/window-lifecycle.ts
+++ b/ui/app/src/lib/window-lifecycle.ts
@@ -50,18 +50,34 @@ export async function attachWindowCloseConfirm(
   return unlisten;
 }
 
-function resolveTauri(): TauriAdapter | null {
+export function resolveTauri(): TauriAdapter | null {
   if (typeof window === 'undefined') {
     return null;
   }
   const t = (window as unknown as { __TAURI__?: TauriRuntime }).__TAURI__;
-  if (!t?.event?.listen || !t.core?.invoke) {
+  if (!t?.core?.invoke) {
     return null;
   }
+  const invoke = t.core.invoke;
+  const currentTarget =
+    t.webviewWindow?.getCurrentWebviewWindow?.() ?? t.window?.getCurrentWindow?.();
+
+  if (currentTarget?.listen) {
+    return {
+      listen: (event, handler) =>
+        currentTarget.listen(event, (envelope: { payload: unknown }) => handler(envelope.payload)),
+      invoke: (cmd, args) => invoke(cmd, args ?? {})
+    };
+  }
+
+  if (!t.event?.listen) {
+    return null;
+  }
+
   return {
     listen: (event, handler) =>
       t.event!.listen(event, (envelope: { payload: unknown }) => handler(envelope.payload)),
-    invoke: (cmd, args) => t.core!.invoke(cmd, args ?? {})
+    invoke: (cmd, args) => invoke(cmd, args ?? {})
   };
 }
 
@@ -75,4 +91,17 @@ interface TauriRuntime {
   core?: {
     invoke: (cmd: string, args: Record<string, unknown>) => Promise<unknown>;
   };
+  window?: {
+    getCurrentWindow?: () => ScopedTauriEventTarget;
+  };
+  webviewWindow?: {
+    getCurrentWebviewWindow?: () => ScopedTauriEventTarget;
+  };
+}
+
+interface ScopedTauriEventTarget {
+  listen: (
+    event: string,
+    handler: (envelope: { payload: unknown }) => void
+  ) => Promise<() => void>;
 }

--- a/ui/app/src/lib/window-title.test.ts
+++ b/ui/app/src/lib/window-title.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { formatWindowTitle, pushWindowTitle } from './window-title';
+
+describe('formatWindowTitle', () => {
+  it('joins vault and note with em dash', () => {
+    expect(formatWindowTitle('work', 'Inbox')).toBe('work — Inbox');
+  });
+
+  it('falls back to vault alone when note is empty', () => {
+    expect(formatWindowTitle('work', '')).toBe('work');
+    expect(formatWindowTitle('work', null)).toBe('work');
+    expect(formatWindowTitle('work', '   ')).toBe('work');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(formatWindowTitle('  work  ', '  My Note  ')).toBe('work — My Note');
+  });
+
+  it('returns empty when both are empty', () => {
+    expect(formatWindowTitle('', null)).toBe('');
+  });
+});
+
+describe('pushWindowTitle', () => {
+  it('invokes set_window_title with formatted title', async () => {
+    const invoke = vi.fn().mockResolvedValue(undefined);
+    await pushWindowTitle('work', 'Note', { invoke });
+    expect(invoke).toHaveBeenCalledWith('set_window_title', { title: 'work — Note' });
+  });
+
+  it('is a no-op when adapter is null', async () => {
+    await expect(pushWindowTitle('work', 'x', null)).resolves.toBeUndefined();
+  });
+
+  it('swallows invoke errors', async () => {
+    const invoke = vi.fn().mockRejectedValue(new Error('nope'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await expect(pushWindowTitle('work', 'x', { invoke })).resolves.toBeUndefined();
+    warn.mockRestore();
+  });
+});

--- a/ui/app/src/lib/window-title.ts
+++ b/ui/app/src/lib/window-title.ts
@@ -1,0 +1,44 @@
+/**
+ * Push `<vault> — <note>` to the Tauri window title via the
+ * `set_window_title` command. In non-Tauri contexts (dev browser, tests)
+ * this is a no-op.
+ */
+
+interface TauriRuntime {
+  core?: {
+    invoke: (cmd: string, args: Record<string, unknown>) => Promise<unknown>;
+  };
+}
+
+export interface WindowTitleAdapter {
+  invoke: (cmd: string, args: Record<string, unknown>) => Promise<unknown>;
+}
+
+export function formatWindowTitle(vault: string, noteTitle: string | null): string {
+  const trimmedVault = vault.trim();
+  const trimmedNote = noteTitle?.trim() ?? '';
+  if (!trimmedVault) return trimmedNote;
+  if (!trimmedNote) return trimmedVault;
+  return `${trimmedVault} — ${trimmedNote}`;
+}
+
+export async function pushWindowTitle(
+  vault: string,
+  noteTitle: string | null,
+  adapter: WindowTitleAdapter | null = resolveTauri()
+): Promise<void> {
+  if (!adapter) return;
+  const title = formatWindowTitle(vault, noteTitle);
+  try {
+    await adapter.invoke('set_window_title', { title });
+  } catch (error) {
+    console.warn('set_window_title failed', error);
+  }
+}
+
+function resolveTauri(): WindowTitleAdapter | null {
+  if (typeof window === 'undefined') return null;
+  const t = (window as unknown as { __TAURI__?: TauriRuntime }).__TAURI__;
+  if (!t?.core?.invoke) return null;
+  return { invoke: (cmd, args) => t.core!.invoke(cmd, args) };
+}

--- a/ui/app/src/routes/+page.svelte
+++ b/ui/app/src/routes/+page.svelte
@@ -20,6 +20,7 @@
 	import ToastStack from '$lib/components/ToastStack.svelte';
 	import VersionBanner from '$lib/components/VersionBanner.svelte';
 	import VaultSwitcher from '$lib/components/VaultSwitcher.svelte';
+	import OpenFolderAsVaultModal from '$lib/components/OpenFolderAsVaultModal.svelte';
 	import { versionMismatch } from '$lib/api/core';
 	import { inputPalette } from '$lib/input-palette.svelte';
 	import { tabStore } from '$lib/tab-store.svelte';
@@ -44,6 +45,7 @@
 	>(null);
 	let rightRailRef = $state<{ refresh: () => void } | null>(null);
 	let activeMiddlePaneItem = $state<CustomItem | null>(null);
+	let showOpenFolderModal = $state(false);
 	let configToastRef = $state<
 		{ show: (message: string, type: 'info' | 'error') => void } | null
 	>(null);
@@ -129,7 +131,15 @@
 
 		void shell.init(vaultParam, vaults);
 
-		return shell.teardown;
+		const openFolderHandler = () => {
+			showOpenFolderModal = true;
+		};
+		window.addEventListener('notesmith://open-folder-as-vault', openFolderHandler);
+
+		return () => {
+			window.removeEventListener('notesmith://open-folder-as-vault', openFolderHandler);
+			shell.teardown();
+		};
 	});
 
 	$effect(() => {
@@ -259,6 +269,10 @@ onClose={() => (activeMiddlePaneItem = null)}
 
 {#if showQuickSwitcher}
 <QuickSwitcher onClose={() => (showQuickSwitcher = false)} />
+{/if}
+
+{#if showOpenFolderModal}
+<OpenFolderAsVaultModal onClose={() => (showOpenFolderModal = false)} />
 {/if}
 
 <ConfigToast bind:this={configToastRef} />

--- a/ui/app/src/routes/+page.svelte
+++ b/ui/app/src/routes/+page.svelte
@@ -26,6 +26,7 @@
 	import { vaultStore } from '$lib/stores.svelte';
 	import { settingsStore } from '$lib/settings.svelte';
 	import { workspaceChromeLayout } from '$lib/workspace-chrome';
+	import { pushWindowTitle } from '$lib/window-title';
 
 	let vaults = $state<string[]>([]);
 	let showCommandPalette = $state(false);
@@ -136,6 +137,12 @@
 		if (vault) {
 			void settingsStore.loadConfig(vault);
 		}
+	});
+
+	$effect(() => {
+		const vault = vaultStore.currentVault;
+		const activeTitle = tabStore.activeTab?.title ?? null;
+		void pushWindowTitle(vault, activeTitle);
 	});
 </script>
 

--- a/ui/app/tests/app-shell.test.ts
+++ b/ui/app/tests/app-shell.test.ts
@@ -440,7 +440,7 @@ test('createAppShell debounces wake resyncs and removes the listener on teardown
 	}
 });
 
-test('createAppShell refreshes vault registrations after vaults.changed events', { concurrency: false }, async () => {
+test('createAppShell refreshes vault registrations after vaults.changed events when not URL-pinned', { concurrency: false }, async () => {
 	stubSvelteRunes();
 
 	const windowStub = createWindowStub();
@@ -486,7 +486,8 @@ test('createAppShell refreshes vault registrations after vaults.changed events',
 	});
 
 	const vaults: string[] = [];
-	await shell.init('work', vaults);
+	// No URL pin → not sticky.
+	await shell.init(null, vaults);
 	assert.deepEqual(vaults, ['work']);
 	assert.equal(vaultStore.currentVault, 'work');
 
@@ -505,6 +506,72 @@ test('createAppShell refreshes vault registrations after vaults.changed events',
 	assert.equal(vaultStore.loadNotesCalls, 2);
 	assert.equal(connectCalls, 2);
 	assert.equal(closeCalls, 1);
+});
+
+test('createAppShell keeps URL-pinned vault sticky even when it disappears from the registry', { concurrency: false }, async () => {
+	stubSvelteRunes();
+
+	const windowStub = createWindowStub();
+	const vaultStore = createVaultStoreStub();
+	const tabStore = createTabStoreStub();
+	const { callbacks } = createCallbacks();
+
+	let onEvent:
+		| ((event: {
+				vault: string;
+				type: string;
+				path: string;
+				timestamp: string;
+		  }) => void)
+		| undefined;
+	let closeCalls = 0;
+	let connectCalls = 0;
+	let listVaultCalls = 0;
+
+	const { createAppShell } = await import('../src/lib/app-shell-core.ts');
+
+	const shell = createAppShell(callbacks, {
+		connectSSE: (_vault, handleEvent) => {
+			connectCalls += 1;
+			onEvent = handleEvent as typeof onEvent;
+			return {
+				close() {
+					closeCalls += 1;
+				}
+			} as EventSource;
+		},
+		listVaults: async () => {
+			listVaultCalls += 1;
+			if (listVaultCalls === 1) {
+				return [{ name: 'work', is_default: true }];
+			}
+			return [{ name: 'home', is_default: true }];
+		},
+		registerHotkeys: () => () => {},
+		vaultStore,
+		tabStore,
+		targetWindow: windowStub.window
+	});
+
+	const vaults: string[] = [];
+	// URL-pinned to 'work' → sticky.
+	await shell.init('work', vaults);
+	assert.equal(vaultStore.currentVault, 'work');
+
+	onEvent?.({
+		vault: 'work',
+		type: 'vaults.changed',
+		path: '',
+		timestamp: new Date().toISOString()
+	});
+	await Promise.resolve();
+	await Promise.resolve();
+
+	// Listed updated, but currentVault stays sticky.
+	assert.equal(listVaultCalls, 2);
+	assert.equal(vaultStore.currentVault, 'work');
+	assert.equal(connectCalls, 1);
+	assert.equal(closeCalls, 0);
 });
 
 test('createAppShell flushes queued saves after SSE reconnects', { concurrency: false }, async () => {


### PR DESCRIPTION
Fixes the red close button on per-vault windows.

## Symptoms

Clicking the OS close button on a vault window did nothing (or, with multiple windows open, closed the wrong window).

## Root cause

Two interacting bugs in the close flow introduced in #105:

1. **Global emit**: `window.emit(CLOSE_REQUESTED_EVENT, ...)` is a broadcast. Every open vault webview received the request — each then invoked `confirm_window_close` from its own context, and each tried to close itself. The 'pending close' marker handed out for window A could be consumed by window B's re-entrant CloseRequested, leaving A stuck.

2. **`webview.close()` reentry**: `confirm_window_close` called `webview.close()`, which fires `CloseRequested` a second time. We then relied on a marker to short-circuit the `prevent_close` branch. The dance is brittle and platform-sensitive.

## Fix

- `emit_to(EventTarget::webview_window(label), ...)` — the request is delivered only to the webview hosting the window whose close was requested.
- `window.destroy()` instead of `window.close()` — destroy skips the close handler entirely, removing the second round trip.
- Dropped the now-unused `PendingCloses` state.
- Moved `VaultWindows` + `windows.json` cleanup into a `WindowEvent::Destroyed` handler so bookkeeping runs for any destruction path.

## Validation

`cargo build`, `cargo clippy -- -D warnings`, `cargo test`, `cargo fmt -- --check` all clean for notesmith-tauri.